### PR TITLE
Make services listen on ipv6 (and ipv4)

### DIFF
--- a/resources/config/imap.toml
+++ b/resources/config/imap.toml
@@ -3,16 +3,16 @@
 #############################################
 
 [server.listener."imap"]
-bind = ["0.0.0.0:143"]
+bind = ["[::]:143"]
 protocol = "imap"
 
 [server.listener."imaptls"]
-bind = ["0.0.0.0:993"]
+bind = ["[::]:993"]
 protocol = "imap"
 tls.implicit = true
 
 [server.listener."sieve"]
-bind = ["0.0.0.0:4190"]
+bind = ["[::]:4190"]
 protocol = "managesieve"
 tls.implicit = true
 

--- a/resources/config/jmap.toml
+++ b/resources/config/jmap.toml
@@ -3,7 +3,7 @@
 #############################################
 
 [server.listener."jmap"]
-bind = ["0.0.0.0:8080"]
+bind = ["[::]:8080"]
 url = "https://__HOST__:8080"
 protocol = "jmap"
 

--- a/resources/config/smtp.toml
+++ b/resources/config/smtp.toml
@@ -3,16 +3,16 @@
 #############################################
 
 [server.listener."smtp"]
-bind = ["0.0.0.0:25"]
+bind = ["[::]:25"]
 greeting = "Stalwart SMTP at your service"
 protocol = "smtp"
 
 [server.listener."submission"]
-bind = ["0.0.0.0:587"]
+bind = ["[::]:587"]
 protocol = "smtp"
 
 [server.listener."submissions"]
-bind = ["0.0.0.0:465"]
+bind = ["[::]:465"]
 protocol = "smtp"
 tls.implicit = true
 


### PR DESCRIPTION
My (test) mailserver is running ipv6 only.... but I had some trouble receiving e-mail, as all services were only listening on the (present, but not routed) ipv4 addresses. This change makes all services listen on [::]:port instead of 0.0.0.0:port