### PR TITLE
Make inbox case-insensitive for IMAP

### DIFF
--- a/crates/imap/src/core/mailbox.rs
+++ b/crates/imap/src/core/mailbox.rs
@@ -495,6 +495,7 @@ impl SessionData {
     }
 
     pub fn get_mailbox_by_name(&self, mailbox_name: &str) -> Option<MailboxId> {
+        let case_insensitive = mailbox_name.to_lowercase() == "inbox";
         if !self.is_all_mailbox(mailbox_name) {
             for account in self.mailboxes.lock().iter() {
                 if account
@@ -503,7 +504,9 @@ impl SessionData {
                     .map_or(true, |p| mailbox_name.starts_with(p))
                 {
                     for (mailbox_name_, mailbox_id_) in account.mailbox_names.iter() {
-                        if mailbox_name_ == mailbox_name {
+                        let exact_match = mailbox_name_ == mailbox_name;
+                        let case_insensitive_match = mailbox_name_.to_lowercase() == mailbox_name.to_lowercase();
+                        if exact_match || (case_insensitive && case_insensitive_match) {
                             return MailboxId {
                                 account_id: account.account_id,
                                 mailbox_id: Some(*mailbox_id_),

--- a/tests/src/imap/mailbox.rs
+++ b/tests/src/imap/mailbox.rs
@@ -46,6 +46,14 @@ pub async fn test(mut imap: &mut ImapConnection, mut imap_check: &mut ImapConnec
             ],
             true,
         );
+    
+    // Ensure INBOX is case-insensitive
+    imap.send("SELECT \"INBOX\"").await;
+    imap.assert_read(Type::Tagged, ResponseType::Ok).await;
+    imap.send("SELECT \"Inbox\"").await;
+    imap.assert_read(Type::Tagged, ResponseType::Ok).await;
+    imap.send("SELECT \"inbox\"").await;
+    imap.assert_read(Type::Tagged, ResponseType::Ok).await;
 
     // Create folders
     imap.send("CREATE \"Tofu\"").await;


### PR DESCRIPTION
Per [RFC3501 section 5.1](https://datatracker.ietf.org/doc/html/rfc3501#section-5.1), inbox should be case-insensitive.