### PR TITLE
Add journal tracing subscriber (Closes #45)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5491,6 +5491,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-journald"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba316a74e8fc3c3896a850dba2375928a9fa171b085ecddfc7c054d39970f3fd"
+dependencies = [
+ "libc",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-log"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5766,6 +5777,7 @@ dependencies = [
  "tokio-rustls 0.24.1",
  "tracing",
  "tracing-appender",
+ "tracing-journald",
  "tracing-opentelemetry",
  "tracing-subscriber",
 ]

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -25,6 +25,7 @@ ahash = { version = "0.8" }
 
 [target.'cfg(unix)'.dependencies]
 privdrop = "0.5.3"
+tracing-journald = "0.3"
 
 [features]
 test_mode = []

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -179,6 +179,17 @@ pub fn enable_tracing(config: &Config, message: &str) -> config::Result<Option<W
 
             Ok(None)
         }
+        #[cfg(unix)]
+        "journal" => {
+            tracing::subscriber::set_global_default(
+                tracing_subscriber::Registry::default()
+                    .with(tracing_journald::layer().failed("Failed to configure journal"))
+                    .with(env_filter),
+            )
+            .failed("Failed to set subscriber");
+
+            Ok(None)
+        }
         _ => Ok(None),
     };
 


### PR DESCRIPTION
(Unix-only) add a journal tracing subscriber option.

Untested yet - treat as WIP unless you're happy with it already. Is there a doc that also needs to be updated?