### PR TITLE
[bug]: Support for skipping ehlo, from mail-send PR #23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2809,7 +2809,7 @@ dependencies = [
 [[package]]
 name = "mail-send"
 version = "0.4.1"
-source = "git+https://github.com/stalwartlabs/mail-send#53904ce6cf4fcb9a42a92a541f5d64d4d972d6cb"
+source = "git+https://github.com/hoxxep/mail-send?rev=1fcb932#1fcb9327895f322e31a84e511a23b3267f4dc710"
 dependencies = [
  "base64 0.20.0",
  "gethostname",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,3 +60,7 @@ incremental = false
 debug-assertions = false
 overflow-checks = false
 rpath = false
+
+# TODO: remove before merge
+[patch."https://github.com/stalwartlabs/mail-send"]
+mail-send = { git = "https://github.com/hoxxep/mail-send", rev = "1fcb932" }

--- a/crates/directory/Cargo.toml
+++ b/crates/directory/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 utils = { path =  "../utils" }
 smtp-proto = { git = "https://github.com/stalwartlabs/smtp-proto" }
 mail-parser = { git = "https://github.com/stalwartlabs/mail-parser", features = ["full_encoding", "serde_support", "ludicrous_mode"] } 
-mail-send = { git = "https://github.com/stalwartlabs/mail-send", default-features = false, features = ["cram-md5", "skip-ehlo"] }
+mail-send = { git = "https://github.com/stalwartlabs/mail-send", default-features = false, features = ["cram-md5"] }
 mail-builder = { git = "https://github.com/stalwartlabs/mail-builder", features = ["ludicrous_mode"] }
 sieve-rs = { git = "https://github.com/stalwartlabs/sieve" } 
 tokio = { version = "1.23", features = ["net"] }

--- a/crates/directory/src/smtp/config.rs
+++ b/crates/directory/src/smtp/config.rs
@@ -62,6 +62,7 @@ impl SmtpDirectory {
                     .value("server.hostname")
                     .unwrap_or("[127.0.0.1]")
                     .to_string(),
+                skip_ehlo: true,
             },
             max_rcpt: config.property_or_static((&prefix, "limits.rcpt"), "10")?,
             max_auth_errors: config.property_or_static((&prefix, "limits.auth-errors"), "3")?,

--- a/crates/imap/Cargo.toml
+++ b/crates/imap/Cargo.toml
@@ -13,7 +13,7 @@ store = { path = "../store" }
 nlp = { path = "../nlp" }
 utils = { path = "../utils" }
 mail-parser = { git = "https://github.com/stalwartlabs/mail-parser", features = ["full_encoding", "ludicrous_mode"] } 
-mail-send = { git = "https://github.com/stalwartlabs/mail-send", default-features = false, features = ["cram-md5", "skip-ehlo"] }
+mail-send = { git = "https://github.com/stalwartlabs/mail-send", default-features = false, features = ["cram-md5"] }
 rustls = "0.21.0"
 rustls-pemfile = "1.0"
 tokio = { version = "1.23", features = ["full"] }

--- a/crates/jmap/Cargo.toml
+++ b/crates/jmap/Cargo.toml
@@ -14,7 +14,7 @@ directory = { path =  "../directory" }
 smtp-proto = { git = "https://github.com/stalwartlabs/smtp-proto" }
 mail-parser = { git = "https://github.com/stalwartlabs/mail-parser", features = ["full_encoding", "serde_support", "ludicrous_mode"] } 
 mail-builder = { git = "https://github.com/stalwartlabs/mail-builder", features = ["ludicrous_mode"] }
-mail-send = { git = "https://github.com/stalwartlabs/mail-send", default-features = false, features = ["cram-md5", "skip-ehlo"] }
+mail-send = { git = "https://github.com/stalwartlabs/mail-send", default-features = false, features = ["cram-md5"] }
 sieve-rs = { git = "https://github.com/stalwartlabs/sieve" } 
 serde = { version = "1.0", features = ["derive"]}
 serde_json = "1.0"

--- a/crates/managesieve/Cargo.toml
+++ b/crates/managesieve/Cargo.toml
@@ -13,7 +13,7 @@ directory = { path = "../directory" }
 store = { path = "../store" }
 utils = { path = "../utils" }
 mail-parser = { git = "https://github.com/stalwartlabs/mail-parser", features = ["full_encoding", "ludicrous_mode"] } 
-mail-send = { git = "https://github.com/stalwartlabs/mail-send", default-features = false, features = ["cram-md5", "skip-ehlo"] }
+mail-send = { git = "https://github.com/stalwartlabs/mail-send", default-features = false, features = ["cram-md5"] }
 sieve-rs = { git = "https://github.com/stalwartlabs/sieve" } 
 rustls = "0.21.0"
 rustls-pemfile = "1.0"

--- a/crates/smtp/Cargo.toml
+++ b/crates/smtp/Cargo.toml
@@ -16,7 +16,7 @@ utils = { path =  "../utils" }
 nlp = { path =  "../nlp" }
 directory = { path =  "../directory" }
 mail-auth = { git = "https://github.com/stalwartlabs/mail-auth" }
-mail-send = { git = "https://github.com/stalwartlabs/mail-send", default-features = false, features = ["cram-md5", "skip-ehlo"] }
+mail-send = { git = "https://github.com/stalwartlabs/mail-send", default-features = false, features = ["cram-md5"] }
 mail-parser = { git = "https://github.com/stalwartlabs/mail-parser", features = ["full_encoding", "ludicrous_mode"] } 
 mail-builder = { git = "https://github.com/stalwartlabs/mail-builder", features = ["ludicrous_mode"] } 
 smtp-proto = { git = "https://github.com/stalwartlabs/smtp-proto" }
@@ -56,8 +56,11 @@ decancer = "1.6.1"
 unicode-security = "0.1.0"
 infer = "0.15.0"
 
+[dev-dependencies]
+mail-auth = { git = "https://github.com/stalwartlabs/mail-auth", features = ["test"] }  # required for mock resolver
+
 [features]
-test_mode = []
+test_mode = ["mail-auth/test"]  # required for mock resolver
 local_delivery = []
 
 #[[bench]]

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -13,7 +13,7 @@ serde = { version = "1.0", features = ["derive"]}
 tracing = "0.1"
 mail-auth = { git = "https://github.com/stalwartlabs/mail-auth" }
 smtp-proto = { git = "https://github.com/stalwartlabs/smtp-proto" }
-mail-send = { git = "https://github.com/stalwartlabs/mail-send", default-features = false, features = ["cram-md5", "skip-ehlo"] }
+mail-send = { git = "https://github.com/stalwartlabs/mail-send", default-features = false, features = ["cram-md5"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-appender = "0.2"
 tracing-opentelemetry = "0.21.0"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -21,7 +21,7 @@ imap_proto = { path = "../crates/imap-proto" }
 smtp = { path = "../crates/smtp", features = ["test_mode", "local_delivery"] }
 managesieve = { path = "../crates/managesieve", features = ["test_mode"] }
 smtp-proto = { git = "https://github.com/stalwartlabs/smtp-proto" }
-mail-send = { git = "https://github.com/stalwartlabs/mail-send", default-features = false, features = ["cram-md5", "skip-ehlo"] }
+mail-send = { git = "https://github.com/stalwartlabs/mail-send", default-features = false, features = ["cram-md5"] }
 mail-auth = { git = "https://github.com/stalwartlabs/mail-auth", features = ["test"] }
 sieve-rs = { git = "https://github.com/stalwartlabs/sieve" } 
 utils = { path = "../crates/utils", features = ["test_mode"] }


### PR DESCRIPTION
Matching PR for https://github.com/stalwartlabs/mail-send/pull/23 which removes the `skip-ehlo` compiler feature in favour of a boolean flag in the `SmtpClientBuilder`.

I believe this is the only usage where it makes a difference, as the smtp/outgoing parts of the codebase create the SmtpClient by hand.