### PR TITLE
Return an error to client if STARTTLS is not available

### DIFF
--- a/crates/smtp/src/inbound/ehlo.rs
+++ b/crates/smtp/src/inbound/ehlo.rs
@@ -115,7 +115,7 @@ impl<T: AsyncWrite + AsyncRead + IsTls + Unpin> Session<T> {
         let mut response = EhloResponse::new(self.instance.hostname.as_str());
         response.capabilities =
             EXT_ENHANCED_STATUS_CODES | EXT_8BIT_MIME | EXT_BINARY_MIME | EXT_SMTP_UTF8;
-        if !self.stream.is_tls() {
+        if self.instance.tls_acceptor.is_some() && !self.stream.is_tls() {
             response.capabilities |= EXT_START_TLS;
         }
         let ec = &self.core.session.config.extensions;

--- a/crates/smtp/src/inbound/session.rs
+++ b/crates/smtp/src/inbound/session.rs
@@ -136,7 +136,7 @@ impl<T: AsyncWrite + AsyncRead + IsTls + Unpin> Session<T> {
                                 self.handle_expn(value).await?;
                             }
                             Request::StartTls => {
-                                if !self.instance.tls_acceptor.is_some() {
+                                if self.instance.tls_acceptor.is_none() {
                                     self.write(b"502 5.5.1 Command not implemented.\r\n")
                                         .await?;
                                 } else if !self.stream.is_tls() {

--- a/crates/smtp/src/inbound/session.rs
+++ b/crates/smtp/src/inbound/session.rs
@@ -136,7 +136,10 @@ impl<T: AsyncWrite + AsyncRead + IsTls + Unpin> Session<T> {
                                 self.handle_expn(value).await?;
                             }
                             Request::StartTls => {
-                                if !self.stream.is_tls() {
+                                if !self.instance.tls_acceptor.is_some() {
+                                    self.write(b"502 5.5.1 Command not implemented.\r\n")
+                                        .await?;
+                                } else if !self.stream.is_tls() {
                                     self.write(b"220 2.0.0 Ready to start TLS.\r\n").await?;
                                     #[cfg(any(test, feature = "test_mode"))]
                                     if self.data.helo_domain.contains("badtls") {


### PR DESCRIPTION
Currently if STARTTLS is not available (e.g. because there is no certificate configured), the server responds with `220 2.0.0 Ready to start TLS.` and then immediately closes the connection, which is confusing.

RFC3207 only specifies a 452 status code, which would probably not be appropriate, since retrying STARTTLS is unlikely to help, but Postfix returns 502, so I figured I'd do the same.