### PR TITLE
Fix Spamhaus DBL queries

### DIFF
--- a/resources/config/spamfilter/scripts/rbl.sieve
+++ b/resources/config/spamfilter/scripts/rbl.sieve
@@ -186,11 +186,11 @@ while "i < domains_len" {
 
     # Query SpamHaus DBL
     let "result" "rsplit_once(dns_query(domain + '.dbl.spamhaus.org', 'ipv4')[0], '.')";
-    if eval "result[0] == '127.0.0'" {
+    if eval "result[0] == '127.0.1'" {
         let "result" "result[1]";
 
         if eval "result == 2" {
-            let "t.DBL_SPAM" "";
+            let "t.DBL_SPAM" "1";
         } elsif eval "result == 4" {
             let "t.DBL_PHISH" "1";
         } elsif eval "result == 5" {


### PR DESCRIPTION
After testing my set-up with https://blt.spamhaus.com/, it turned out that Spamhaus DBL was not working as expected.

See https://docs.spamhaus.com/datasets/docs/source/10-data-type-documentation/datasets/030-datasets.html#dbl for docs on returned IP addresses and their meaning, together with https://www.spamhaus.org/faq/section/Spamhaus%20DBL#291 for an extensive list.