### PR TITLE
[bug]: Fix hyper-util dep, add explicit versioning to external git deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,7 +306,7 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fcf00bc6d5abb29b5f97e3c61a90b6d3caa12f3faf897d4a3e3607c050a35a7"
 dependencies = [
- "http",
+ "http 0.2.9",
  "log",
  "rustls 0.20.9",
  "serde",
@@ -359,7 +359,7 @@ dependencies = [
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
- "http",
+ "http 0.2.9",
  "http-body 0.4.5",
  "hyper 0.14.27",
  "itoa",
@@ -385,7 +385,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
+ "http 0.2.9",
  "http-body 0.4.5",
  "mime",
  "rustversion",
@@ -1631,7 +1631,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0322eefcd026820bbb430b427f0e9b22fc3952f163df23b74a3c5639bae32f0f"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.9",
  "httparse",
  "memchr",
  "mime",
@@ -1906,8 +1906,27 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.9",
  "indexmap 1.9.3",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d308f63daf4181410c242d34c11f928dcb3aa105852019e043c9d1f4e4368a"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 1.0.0",
+ "indexmap 2.0.2",
  "slab",
  "tokio",
  "tokio-util",
@@ -2074,36 +2093,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b32afd38673a8016f7c9ae69e5af41a58f81b1d31689040f2f1959594ce194ea"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.9",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "http-body"
-version = "1.0.0-rc.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951dfc2e32ac02d67c90c0d65bd27009a635dc9b381a2cc7d284ab01e3a0150d"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
 dependencies = [
  "bytes",
- "http",
+ "http 1.0.0",
 ]
 
 [[package]]
 name = "http-body-util"
-version = "0.1.0-rc.3"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ef12f041acdd397010e5fb6433270c147d3b8b2d0a840cd7fff8e531dca5c8"
+checksum = "41cb79eb393015dadd30fc252023adb0b2400a0caee0fa2a077e6e21a551e840"
 dependencies = [
  "bytes",
  "futures-util",
- "http",
- "http-body 1.0.0-rc.2",
+ "http 1.0.0",
+ "http-body 1.0.0",
  "pin-project-lite",
 ]
 
@@ -2135,8 +2165,8 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
+ "h2 0.3.21",
+ "http 0.2.9",
  "http-body 0.4.5",
  "httparse",
  "httpdate",
@@ -2151,23 +2181,21 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.0.0-rc.4"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d280a71f348bcc670fc55b02b63c53a04ac0bf2daff2980795aeaf53edae10e6"
+checksum = "403f9214f3e703236b221f1a9cd88ec8b4adfa5296de01ab96216361f4692f56"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2",
- "http",
- "http-body 1.0.0-rc.2",
+ "h2 0.4.0",
+ "http 1.0.0",
+ "http-body 1.0.0",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
  "tokio",
- "tracing",
- "want",
 ]
 
 [[package]]
@@ -2177,7 +2205,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d78e1e73ec14cf7375674f74d7dde185c8206fd9dea6fb6295e8a98098aaa97"
 dependencies = [
  "futures-util",
- "http",
+ "http 0.2.9",
  "hyper 0.14.27",
  "rustls 0.21.7",
  "tokio",
@@ -2198,16 +2226,16 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.0.0"
-source = "git+https://github.com/hyperium/hyper-util#1ed4c2ccdb23f576eb7024555f08b376b9d5c9eb"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ca339002caeb0d159cc6e023dff48e199f081e42fa039895c7c6f38b37f2e9d"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body 1.0.0-rc.2",
- "hyper 1.0.0-rc.4",
- "once_cell",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "hyper 1.0.1",
  "pin-project-lite",
  "socket2 0.5.5",
  "tokio",
@@ -2479,7 +2507,7 @@ dependencies = [
  "futures-util",
  "hkdf",
  "http-body-util",
- "hyper 1.0.0-rc.4",
+ "hyper 1.0.1",
  "hyper-util",
  "jmap_proto",
  "mail-builder",
@@ -3256,7 +3284,7 @@ checksum = "c7594ec0e11d8e33faf03530a4c49af7064ebba81c1480e01be67d90b356508b"
 dependencies = [
  "async-trait",
  "bytes",
- "http",
+ "http 0.2.9",
  "opentelemetry_api",
  "reqwest",
 ]
@@ -3269,7 +3297,7 @@ checksum = "7e5e5a5c4135864099f3faafbe939eb4d7f9b80ebf68a8448da961b32a7c1275"
 dependencies = [
  "async-trait",
  "futures-core",
- "http",
+ "http 0.2.9",
  "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry-semantic-conventions",
@@ -4022,8 +4050,8 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
- "http",
+ "h2 0.3.21",
+ "http 0.2.9",
  "http-body 0.4.5",
  "hyper 0.14.27",
  "hyper-rustls",
@@ -4221,7 +4249,7 @@ dependencies = [
  "futures",
  "hex",
  "hmac 0.12.1",
- "http",
+ "http 0.2.9",
  "log",
  "maybe-async 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "md5",
@@ -4749,7 +4777,7 @@ dependencies = [
  "directory",
  "form_urlencoded",
  "http-body-util",
- "hyper 1.0.0-rc.4",
+ "hyper 1.0.1",
  "hyper-util",
  "idna 0.4.0",
  "imagesize",
@@ -5308,7 +5336,7 @@ dependencies = [
  "flate2",
  "futures",
  "http-body-util",
- "hyper 1.0.0-rc.4",
+ "hyper 1.0.1",
  "hyper-util",
  "imap",
  "imap_proto",
@@ -5548,8 +5576,8 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "h2",
- "http",
+ "h2 0.3.21",
+ "http 0.2.9",
  "http-body 0.4.5",
  "hyper 0.14.27",
  "hyper-timeout",
@@ -5717,7 +5745,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http",
+ "http 0.2.9",
  "httparse",
  "log",
  "rand 0.8.5",
@@ -5738,7 +5766,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http",
+ "http 0.2.9",
  "httparse",
  "log",
  "rand 0.8.5",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -11,8 +11,8 @@ readme = "README.md"
 resolver = "2"
 
 [dependencies]
-jmap-client = { git = "https://github.com/stalwartlabs/jmap-client", features = ["async"] } 
-mail-parser = { git = "https://github.com/stalwartlabs/mail-parser", features = ["full_encoding", "serde_support", "ludicrous_mode"] } 
+jmap-client = { version = "0.3", git = "https://github.com/stalwartlabs/jmap-client", features = ["async"] }
+mail-parser = { version = "0.9", git = "https://github.com/stalwartlabs/mail-parser", features = ["full_encoding", "serde_support", "ludicrous_mode"] }
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls-webpki-roots"]}
 tokio = { version = "1.23", features = ["full"] }
 num_cpus = "1.13.1"

--- a/crates/directory/Cargo.toml
+++ b/crates/directory/Cargo.toml
@@ -6,11 +6,11 @@ resolver = "2"
 
 [dependencies]
 utils = { path =  "../utils" }
-smtp-proto = { git = "https://github.com/stalwartlabs/smtp-proto" }
-mail-parser = { git = "https://github.com/stalwartlabs/mail-parser", features = ["full_encoding", "serde_support", "ludicrous_mode"] } 
-mail-send = { git = "https://github.com/stalwartlabs/mail-send", default-features = false, features = ["cram-md5", "skip-ehlo"] }
-mail-builder = { git = "https://github.com/stalwartlabs/mail-builder", features = ["ludicrous_mode"] }
-sieve-rs = { git = "https://github.com/stalwartlabs/sieve" } 
+smtp-proto = { version = "0.1", git = "https://github.com/stalwartlabs/smtp-proto" }
+mail-parser = { version = "0.9", git = "https://github.com/stalwartlabs/mail-parser", features = ["full_encoding", "serde_support", "ludicrous_mode"] }
+mail-send = { version = "0.4", git = "https://github.com/stalwartlabs/mail-send", default-features = false, features = ["cram-md5", "skip-ehlo"] }
+mail-builder = { version = "0.3", git = "https://github.com/stalwartlabs/mail-builder", features = ["ludicrous_mode"] }
+sieve-rs = { version = "0.3", git = "https://github.com/stalwartlabs/sieve" }
 tokio = { version = "1.23", features = ["net"] }
 tokio-rustls = { version = "0.24.0"}
 rustls = "0.21.0"

--- a/crates/imap-proto/Cargo.toml
+++ b/crates/imap-proto/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 
 [dependencies]
 jmap_proto = { path = "../jmap-proto" }
-mail-parser = { git = "https://github.com/stalwartlabs/mail-parser", features = ["full_encoding", "serde_support", "ludicrous_mode"] } 
+mail-parser = { version = "0.9", git = "https://github.com/stalwartlabs/mail-parser", features = ["full_encoding", "serde_support", "ludicrous_mode"] }
 ahash = { version = "0.8" }
 chrono = { version = "0.4"}
 

--- a/crates/imap/Cargo.toml
+++ b/crates/imap/Cargo.toml
@@ -12,8 +12,8 @@ directory = { path = "../directory" }
 store = { path = "../store" }
 nlp = { path = "../nlp" }
 utils = { path = "../utils" }
-mail-parser = { git = "https://github.com/stalwartlabs/mail-parser", features = ["full_encoding", "ludicrous_mode"] } 
-mail-send = { git = "https://github.com/stalwartlabs/mail-send", default-features = false, features = ["cram-md5", "skip-ehlo"] }
+mail-parser = { version = "0.9", git = "https://github.com/stalwartlabs/mail-parser", features = ["full_encoding", "ludicrous_mode"] }
+mail-send = { version = "0.4", git = "https://github.com/stalwartlabs/mail-send", default-features = false, features = ["cram-md5", "skip-ehlo"] }
 rustls = "0.21.0"
 rustls-pemfile = "1.0"
 tokio = { version = "1.23", features = ["full"] }

--- a/crates/jmap-proto/Cargo.toml
+++ b/crates/jmap-proto/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 [dependencies]
 store = { path = "../store" }
 utils = { path = "../utils" }
-mail-parser = { git = "https://github.com/stalwartlabs/mail-parser", features = ["full_encoding", "serde_support", "ludicrous_mode"] } 
+mail-parser = { version = "0.9", git = "https://github.com/stalwartlabs/mail-parser", features = ["full_encoding", "serde_support", "ludicrous_mode"] }
 fast-float = "0.2.0"
 serde = { version = "1.0", features = ["derive"]}
 ahash = { version = "0.8.0", features = ["serde"] }

--- a/crates/jmap/Cargo.toml
+++ b/crates/jmap/Cargo.toml
@@ -11,15 +11,15 @@ jmap_proto = { path = "../jmap-proto" }
 smtp = { path =  "../smtp" }
 utils = { path =  "../utils" }
 directory = { path =  "../directory" }
-smtp-proto = { git = "https://github.com/stalwartlabs/smtp-proto" }
-mail-parser = { git = "https://github.com/stalwartlabs/mail-parser", features = ["full_encoding", "serde_support", "ludicrous_mode"] } 
-mail-builder = { git = "https://github.com/stalwartlabs/mail-builder", features = ["ludicrous_mode"] }
-mail-send = { git = "https://github.com/stalwartlabs/mail-send", default-features = false, features = ["cram-md5", "skip-ehlo"] }
-sieve-rs = { git = "https://github.com/stalwartlabs/sieve" } 
+smtp-proto = { version = "0.1", git = "https://github.com/stalwartlabs/smtp-proto" }
+mail-parser = { version = "0.9", git = "https://github.com/stalwartlabs/mail-parser", features = ["full_encoding", "serde_support", "ludicrous_mode"] }
+mail-builder = { version = "0.3", git = "https://github.com/stalwartlabs/mail-builder", features = ["ludicrous_mode"] }
+mail-send = { version = "0.4", git = "https://github.com/stalwartlabs/mail-send", default-features = false, features = ["cram-md5", "skip-ehlo"] }
+sieve-rs = { version = "0.3", git = "https://github.com/stalwartlabs/sieve" }
 serde = { version = "1.0", features = ["derive"]}
 serde_json = "1.0"
-hyper = { version = "1.0.0-rc.4", features = ["server", "http1", "http2"] }
-hyper-util = { git = "https://github.com/hyperium/hyper-util" }
+hyper = { version = "1.0", features = ["server", "http1", "http2"] }
+hyper-util = { version = "0.1", features = ["tokio"] }
 http-body-util = "0.1.0-rc.3"
 form_urlencoded = "1.1.0"
 tracing = "0.1"

--- a/crates/managesieve/Cargo.toml
+++ b/crates/managesieve/Cargo.toml
@@ -12,9 +12,9 @@ jmap_proto = { path = "../jmap-proto" }
 directory = { path = "../directory" }
 store = { path = "../store" }
 utils = { path = "../utils" }
-mail-parser = { git = "https://github.com/stalwartlabs/mail-parser", features = ["full_encoding", "ludicrous_mode"] } 
-mail-send = { git = "https://github.com/stalwartlabs/mail-send", default-features = false, features = ["cram-md5", "skip-ehlo"] }
-sieve-rs = { git = "https://github.com/stalwartlabs/sieve" } 
+mail-parser = { version = "0.9", git = "https://github.com/stalwartlabs/mail-parser", features = ["full_encoding", "ludicrous_mode"] }
+mail-send = { version = "0.4", git = "https://github.com/stalwartlabs/mail-send", default-features = false, features = ["cram-md5", "skip-ehlo"] }
+sieve-rs = { version = "0.3", git = "https://github.com/stalwartlabs/sieve" }
 rustls = "0.21.0"
 rustls-pemfile = "1.0"
 tokio = { version = "1.23", features = ["full"] }

--- a/crates/smtp/Cargo.toml
+++ b/crates/smtp/Cargo.toml
@@ -15,20 +15,20 @@ resolver = "2"
 utils = { path =  "../utils" }
 nlp = { path =  "../nlp" }
 directory = { path =  "../directory" }
-mail-auth = { git = "https://github.com/stalwartlabs/mail-auth" }
-mail-send = { git = "https://github.com/stalwartlabs/mail-send", default-features = false, features = ["cram-md5", "skip-ehlo"] }
-mail-parser = { git = "https://github.com/stalwartlabs/mail-parser", features = ["full_encoding", "ludicrous_mode"] } 
-mail-builder = { git = "https://github.com/stalwartlabs/mail-builder", features = ["ludicrous_mode"] } 
-smtp-proto = { git = "https://github.com/stalwartlabs/smtp-proto" }
-sieve-rs = { git = "https://github.com/stalwartlabs/sieve" } 
+mail-auth = { version = "0.3", git = "https://github.com/stalwartlabs/mail-auth" }
+mail-send = { version = "0.4", git = "https://github.com/stalwartlabs/mail-send", default-features = false, features = ["cram-md5", "skip-ehlo"] }
+mail-parser = { version = "0.9", git = "https://github.com/stalwartlabs/mail-parser", features = ["full_encoding", "ludicrous_mode"] }
+mail-builder = { version = "0.3", git = "https://github.com/stalwartlabs/mail-builder", features = ["ludicrous_mode"] }
+smtp-proto = { version = "0.1", git = "https://github.com/stalwartlabs/smtp-proto" }
+sieve-rs = { version = "0.3", git = "https://github.com/stalwartlabs/sieve" }
 ahash = { version = "0.8" }
 rustls = "0.21.0"
 rustls-pemfile = "1.0"
 tokio = { version = "1.23", features = ["full"] }
 tokio-rustls = { version = "0.24.0"}
 webpki-roots = { version = "0.25"}
-hyper = { version = "1.0.0-rc.4", features = ["server", "http1", "http2"] }
-hyper-util = { git = "https://github.com/hyperium/hyper-util" }
+hyper = { version = "1.0", features = ["server", "http1", "http2"] }
+hyper-util = { version = "0.1", features = ["tokio"] }
 http-body-util = "0.1.0-rc.3"
 form_urlencoded = "1.1.0"
 sha1 = "0.10"

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -11,9 +11,9 @@ tokio = { version = "1.23", features = ["net", "macros"] }
 tokio-rustls = { version = "0.24.0"}
 serde = { version = "1.0", features = ["derive"]}
 tracing = "0.1"
-mail-auth = { git = "https://github.com/stalwartlabs/mail-auth" }
-smtp-proto = { git = "https://github.com/stalwartlabs/smtp-proto" }
-mail-send = { git = "https://github.com/stalwartlabs/mail-send", default-features = false, features = ["cram-md5", "skip-ehlo"] }
+mail-auth = { version = "0.3", git = "https://github.com/stalwartlabs/mail-auth" }
+smtp-proto = { version = "0.1", git = "https://github.com/stalwartlabs/smtp-proto" }
+mail-send = { version = "0.4", git = "https://github.com/stalwartlabs/mail-send", default-features = false, features = ["cram-md5", "skip-ehlo"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-appender = "0.2"
 tracing-opentelemetry = "0.21.0"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -20,13 +20,13 @@ imap = { path = "../crates/imap", features = ["test_mode"] }
 imap_proto = { path = "../crates/imap-proto" }
 smtp = { path = "../crates/smtp", features = ["test_mode", "local_delivery"] }
 managesieve = { path = "../crates/managesieve", features = ["test_mode"] }
-smtp-proto = { git = "https://github.com/stalwartlabs/smtp-proto" }
-mail-send = { git = "https://github.com/stalwartlabs/mail-send", default-features = false, features = ["cram-md5", "skip-ehlo"] }
-mail-auth = { git = "https://github.com/stalwartlabs/mail-auth", features = ["test"] }
-sieve-rs = { git = "https://github.com/stalwartlabs/sieve" } 
+smtp-proto = { version = "0.1", git = "https://github.com/stalwartlabs/smtp-proto" }
+mail-send = { version = "0.4", git = "https://github.com/stalwartlabs/mail-send", default-features = false, features = ["cram-md5", "skip-ehlo"] }
+mail-auth = { version = "0.3", git = "https://github.com/stalwartlabs/mail-auth", features = ["test"] }
+sieve-rs = { version = "0.3", git = "https://github.com/stalwartlabs/sieve" }
 utils = { path = "../crates/utils", features = ["test_mode"] }
-jmap-client = { git = "https://github.com/stalwartlabs/jmap-client", features = ["websockets", "debug", "async"] } 
-mail-parser = { git = "https://github.com/stalwartlabs/mail-parser", features = ["full_encoding", "serde_support", "ludicrous_mode"] } 
+jmap-client = { version = "0.3", git = "https://github.com/stalwartlabs/jmap-client", features = ["websockets", "debug", "async"] }
+mail-parser = { version = "0.9", git = "https://github.com/stalwartlabs/mail-parser", features = ["full_encoding", "serde_support", "ludicrous_mode"] }
 tokio = { version = "1.23", features = ["full"] }
 tokio-rustls = { version = "0.24.0"}
 rustls = "0.21.0"
@@ -42,8 +42,8 @@ reqwest = { version = "0.11", default-features = false, features = ["rustls-tls-
 bytes = "1.4.0"
 futures = "0.3"
 ece = "2.2"
-hyper = { version = "1.0.0-rc.4", features = ["server", "http1", "http2"] }
-hyper-util = { git = "https://github.com/hyperium/hyper-util" }
+hyper = { version = "1.0", features = ["server", "http1", "http2"] }
+hyper-util = { version = "0.1", features = ["tokio"] }
 http-body-util = "0.1.0-rc.3"
 base64 = "0.21"
 dashmap = "5.4"


### PR DESCRIPTION
`hyper-util` dependency broke with new feature-gating, and is also now available directly on crates.io.

I'm currently trying to use the `smtp` crate for ingesting mail into a wider application, and I would prefer to be able to version against a fixed `mail-server` and upgrade manually. Therefore I've also specified versions for all stalwart dependencies too.

I am depending on a specific revision of `mail-server` (using the smtp crate as an SMTP receiver), but in order to ensure the other packages stay fixed, I have to introduce a large set of patches to fix the dependencies locally, such as:
```toml
[patch."https://github.com/stalwartlabs/mail-auth"]
mail-auth = { git = "https://github.com/stalwartlabs/mail-auth?rev=191189d", rev = "191189d" }
[patch."https://github.com/stalwartlabs/mail-builder"]
mail-builder = { git = "https://github.com/stalwartlabs/mail-builder?rev=665f46d", rev = "665f46d" }
[patch."https://github.com/stalwartlabs/mail-parser"]
mail-parser = { git = "https://github.com/stalwartlabs/mail-parser?rev=b6c080f", rev = "b6c080f" }
[patch."https://github.com/stalwartlabs/mail-send"]
mail-send = { git = "https://github.com/stalwartlabs/mail-send?rev=53904ce", rev = "53904ce" }
[patch."https://github.com/stalwartlabs/mail-server"]
mail-server = { git = "https://github.com/stalwartlabs/mail-server?rev=f9b37a3", rev = "f9b37a3" }
[patch."https://github.com/stalwartlabs/seive-rs"]
sieve-rs = { git = "https://github.com/stalwartlabs/sieve?rev=b7b62b3", rev = "b7b62b3" }
[patch."https://github.com/stalwartlabs/smtp-proto"]
smtp-proto = { git = "https://github.com/stalwartlabs/smtp-proto?rev=d5949da", rev = "d5949da" }
[patch."https://github.com/hyperium/hyper-util"]
hyper-util = { git = "https://github.com/hyperium/hyper-util?rev=1ed4c2c", rev = "1ed4c2c" }
```

This could be avoided if all dependencies used crates.io packages and semver, which should be as simple as adding `version = "x.x"` into the `mail-server` dependencies as happens in the other stalwart packages.

If you'd prefer to centralise the dependency versions, they could all be moved into the workspace `Cargo.toml` so that including dependencies is as simple as `package = { workspace = true }`. I'm happy to make a PR to do this if desirable! 

Thanks again for all of the stalwart work.

Cheers,
Liam