### PR TITLE
[enhancement]: Add .editorconfig and JetBrains .idea gitignore

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,4 @@
+# https://EditorConfig.org
 root = true
 
 [*]

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+charset = utf-8
+indent_size = 4
+indent_style = space
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+max_line_length = 100

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /target
 .vscode
+.idea
 *.failed
 *_failed
 stalwart.toml


### PR DESCRIPTION
As suggested in #141. Separating out adding a `.editorconfig` so that popular IDEs automatically insert trailing newlines at the end of files.