### PR TITLE
Fix bug: the superuser-group is never read

### DIFF
--- a/crates/directory/src/config.rs
+++ b/crates/directory/src/config.rs
@@ -364,7 +364,7 @@ impl DirectoryOptions {
             catch_all: AddressMapping::from_config(config, (&key, "options.catch-all"))?,
             subaddressing: AddressMapping::from_config(config, (&key, "options.subaddressing"))?,
             superuser_group: config
-                .value("options.superuser-group")
+                .value((&key, "options.superuser-group"))
                 .unwrap_or("superusers")
                 .to_string(),
         })


### PR DESCRIPTION
When reading the configuration values the prefix was missing. That way
the directory."name".options.superuser-group setting was ignored and
instead allways on the default "superusers"