### PR TITLE
There is no group ACCOUNT_NAME

### DIFF
--- a/crates/install/src/main.rs
+++ b/crates/install/src/main.rs
@@ -446,7 +446,7 @@ fn main() -> std::io::Result<()> {
         {
             let mut cmd = std::process::Command::new("chown");
             cmd.arg("-R")
-                .arg(format!("{}:{}", ACCOUNT_NAME, ACCOUNT_NAME))
+                .arg(format!("{}", ACCOUNT_NAME))
                 .arg(&base_path);
             if let Err(err) = cmd.status() {
                 eprintln!("Warning: Failed to set permissions: {}", err);


### PR DESCRIPTION
It should prevent
  chown: invalid group: ‘stalwart-mail:stalwart-mail’
error