### PR TITLE
Coexist with other mail servers

### DIFF
--- a/resources/systemd/stalwart-mail.service
+++ b/resources/systemd/stalwart-mail.service
@@ -1,6 +1,5 @@
 [Unit]
 Description=Stalwart __TITLE__ Server
-Conflicts=postfix.service sendmail.service exim4.service
 ConditionPathExists=__PATH__/etc/config.toml
 After=network-online.target
  


### PR DESCRIPTION
Removing the "conflict" makes it possible to have multiple mail servers running at the same time. Each listening on their own TCP port.

Use case:
Existing email server forwards to Stalwart for DKIM signing.