### PR TITLE
Use relaxed DNS parsing, allowing underscores in DNS labels

### DIFF
--- a/crates/smtp/src/outbound/dane/dnssec.rs
+++ b/crates/smtp/src/outbound/dane/dnssec.rs
@@ -66,7 +66,9 @@ impl Resolvers {
         }
 
         let mut entries = Vec::new();
-        let tlsa_lookup = match self.dnssec.resolver.tlsa_lookup(key.as_ref()).await {
+
+        let name = self.dns.parse_name(key.as_ref())?;
+        let tlsa_lookup = match self.dnssec.resolver.tlsa_lookup(name).await {
             Ok(tlsa_lookup) => tlsa_lookup,
             Err(err) => {
                 return match &err.kind() {


### PR DESCRIPTION
With the default hickory-dns name parsing, DNS labels cannot contain underscores due to a certain interpretation of RFCs which disallow usage for naming of hosts. However, DNS labels are allowed and do contain underscores, which causes issues with mail delivery.

Most usages of hickory-dns are corrected in https://github.com/stalwartlabs/mail-auth/pull/25 which also adds a parsing helper function. The PR also contains additional reasoning and examples of mail flow issues.

To test this PR, a branch containing the Cargo references to a fixed mail-auth branch is provided here: https://github.com/fabian-z/mail-server/tree/fix-dns-build

This corresponds to
https://github.com/hickory-dns/hickory-dns issue #1904, #2009
