### PR TITLE
Username of only eight characters on Linux

### DIFF
--- a/crates/install/src/main.rs
+++ b/crates/install/src/main.rs
@@ -43,7 +43,7 @@ const SERVICE: &str = include_str!("../../../resources/systemd/stalwart-mail.ser
 const SERVICE: &str = include_str!("../../../resources/systemd/stalwart.mail.plist");
 
 #[cfg(target_os = "linux")]
-const ACCOUNT_NAME: &str = "stalwart-mail";
+const ACCOUNT_NAME: &str = "stalwart"; // Some utilties truncate username at eight characters length
 #[cfg(target_os = "macos")]
 const ACCOUNT_NAME: &str = "_stalwart-mail";
 


### PR DESCRIPTION
To prevent truncation by `ps -ef` into 'stalwar+' as in

  $ ps -ef | grep stalwart
  root     1466199       1  0 Dec14 ?        00:00:00 sudo stalwart-mail --config /home/stappers/stalwart/config.toml
  root     1466200 1466199  0 Dec14 pts/2    00:00:00 sudo stalwart-mail --config /home/stappers/stalwart/config.toml
  stalwar+ 1466201 1466200  0 Dec14 pts/2    00:00:16 stalwart-mail --config /home/stappers/stalwart/config.toml
  stappers 1514033 1504032  0 10:59 pts/3    00:00:00 grep stalwart
  $