### PR TITLE
Fix default Postgres schema config

### DIFF
--- a/resources/config/store/postgresql.toml
+++ b/resources/config/store/postgresql.toml
@@ -23,7 +23,7 @@ allow-invalid-certs = false
 
 #[store."postgresql".init]
 #execute = [
-#    "CREATE TABLE IF NOT EXISTS accounts (name TEXT PRIMARY KEY, secret TEXT, description TEXT, type TEXT NOT NULL, quota INTEGER DEFAULT 0, active BOOLEAN DEFAULT 1)",
+#    "CREATE TABLE IF NOT EXISTS accounts (name TEXT PRIMARY KEY, secret TEXT, description TEXT, type TEXT NOT NULL, quota INTEGER DEFAULT 0, active BOOLEAN DEFAULT TRUE)",
 #    "CREATE TABLE IF NOT EXISTS group_members (name TEXT NOT NULL, member_of TEXT NOT NULL, PRIMARY KEY (name, member_of))",
 #    "CREATE TABLE IF NOT EXISTS emails (name TEXT NOT NULL, address TEXT NOT NULL, type TEXT, PRIMARY KEY (name, address))"
 #]


### PR DESCRIPTION
The config update counterpart to https://github.com/stalwartlabs/website/pull/13, copied here:

> When setting up a Postgres 15 Stalwart instance, I got the following error:
> 
> ```
> 2024-01-15T03:16:18.685515Z  WARN store::config: Failed to initialize store "postgresql": Internal Error: PostgreSQL error: db error: ERROR: column "active" is of type boolean but default expression is of type integer
> ```
> 
> This change fixes that issue in the docs, I'll send an equivalent PR on the code side of things