### PR TITLE
Add cli command to generate password hashes for storage in external directories

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -16,7 +16,7 @@ mail-parser = { version = "0.9", features = ["full_encoding", "serde_support", "
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-webpki-roots"]}
 tokio = { version = "1.23", features = ["full"] }
 num_cpus = "1.13.1"
-clap = { version = "4.1.6", features = ["derive"] }
+clap = { version = "4.1.6", features = ["derive", "env"] }
 prettytable-rs = "0.10.0"
 rpassword = "7.0"
 indicatif = "0.17.0"

--- a/crates/cli/src/modules/account.rs
+++ b/crates/cli/src/modules/account.rs
@@ -65,6 +65,20 @@ impl AccountCommands {
                     .await;
                 eprintln!("Successfully created account {name:?} with id {account_id}.");
             }
+            AccountCommands::HashPassword {
+                password,
+                algorithm,
+            } => {
+                let hashed = match algorithm.as_str() {
+                    "Bcrypt" => pwhash::bcrypt::hash(password).unwrap(),
+                    "Sha512-Crypt" => pwhash::sha512_crypt::hash(password).unwrap(),
+                    _ => {
+                        eprintln!("Error: unknown hash/crypt algorithm '{}'", algorithm);
+                        return;
+                    }
+                };
+                println!("{}", hashed);
+            }
             AccountCommands::Update {
                 name,
                 new_name,

--- a/crates/cli/src/modules/cli.rs
+++ b/crates/cli/src/modules/cli.rs
@@ -113,6 +113,16 @@ pub enum AccountCommands {
         member_of: Option<Vec<String>>,
     },
 
+    /// Generate a hash for a given password
+    HashPassword {
+        /// The password to use as secret
+        #[clap(short, long, env = "PASSWORD")]
+        password: String,
+        /// The algorithm to use
+        #[clap(short, long, default_value = "Sha512-Crypt", value_parser = clap::builder::PossibleValuesParser::new(["Sha512-Crypt", "Bcrypt"]))]
+        algorithm: String,
+    },
+
     /// Update an existing user account
     Update {
         /// Account login


### PR DESCRIPTION
This pull-request add a command to the CLI that generates a hashed password from the provided secret. This will be handy when using an external directory.

Background: I had trouble getting Stalwart when using passwords I already had in a SQL database. After multiple tries, I simply adopted the CLI to generate me a hash for my password and overwrote my SQL data.

I understand that you do not accept pull requests at this point in time but I wrote the code already and it would be a waste to simply delete it again. Maybe it become handy in the future. Thank you and keep up the good work! 