### PR TITLE
Make initial admin password configurable via an environment variable

### DIFF
--- a/crates/common/src/manager/boot.rs
+++ b/crates/common/src/manager/boot.rs
@@ -293,11 +293,13 @@ fn quickstart(path: impl Into<PathBuf>) {
         }
     }
 
-    let admin_pass = thread_rng()
-        .sample_iter(Alphanumeric)
-        .take(10)
-        .map(char::from)
-        .collect::<String>();
+    let admin_pass = std::env::var("STALWART_INITIAL_ADMIN_PASSWORD").unwrap_or_else(|_| {
+        thread_rng()
+            .sample_iter(Alphanumeric)
+            .take(10)
+            .map(char::from)
+            .collect::<String>()
+    });
 
     std::fs::write(
         path.join("etc").join("config.toml"),


### PR DESCRIPTION
This may be useful for some users running Stalwart in Docker or packaging it for certain "app store" server systems.