### PR TITLE
Update stalwart-mail.service

### DIFF
--- a/resources/systemd/stalwart-mail.service
+++ b/resources/systemd/stalwart-mail.service
@@ -13,8 +13,8 @@ Restart=on-failure
 RestartSec=5
 ExecStart=__PATH__/bin/stalwart-mail --config=__PATH__/etc/config.toml
 PermissionsStartOnly=true
-StandardOutput=syslog
-StandardError=syslog
+StandardOutput=journal
+StandardError=journal
 SyslogIdentifier=stalwart-mail
  
 [Install]


### PR DESCRIPTION
systemd deprecated `syslog` output and automatically converts it to `journal`. Making the change in the unit file will silence the warning notice on service (re)start.

Closes #45 