### PR TITLE
Remove StandardOutput, StandardError in service

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -137,7 +137,7 @@ Description=Stalwart Mail Server Server
 Conflicts=postfix.service sendmail.service exim4.service
 ConditionPathExists=__PATH__/etc/config.toml
 After=network-online.target
- 
+
 [Service]
 Type=simple
 LimitNOFILE=65536
@@ -147,10 +147,8 @@ Restart=on-failure
 RestartSec=5
 ExecStart=__PATH__/bin/stalwart-mail --config=__PATH__/etc/config.toml
 PermissionsStartOnly=true
-StandardOutput=syslog
-StandardError=syslog
 SyslogIdentifier=stalwart-mail
- 
+
 [Install]
 WantedBy=multi-user.target
 EOF

--- a/resources/systemd/stalwart-mail.service
+++ b/resources/systemd/stalwart-mail.service
@@ -3,7 +3,7 @@ Description=Stalwart Mail Server Server
 Conflicts=postfix.service sendmail.service exim4.service
 ConditionPathExists=__PATH__/etc/config.toml
 After=network-online.target
- 
+
 [Service]
 Type=simple
 LimitNOFILE=65536
@@ -13,9 +13,7 @@ Restart=on-failure
 RestartSec=5
 ExecStart=__PATH__/bin/stalwart-mail --config=__PATH__/etc/config.toml
 PermissionsStartOnly=true
-StandardOutput=journal
-StandardError=journal
 SyslogIdentifier=stalwart-mail
- 
+
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
systemd 249 (used in Ubuntu 22.04 LTS) throws the following error:

/etc/systemd/system/stalwart-mail.service:16: Standard output type syslog is obsolete, automatically updating to journal. Please update your unit file, and consider removing the setting altogether.

/etc/systemd/system/stalwart-mail.service:17: Standard output type syslog is obsolete, automatically updating to journal. Please update your unit file, and consider removing the setting altogether.

This is caused by StandardOutput=syslog and StandardError=syslog found in install.sh, which are as the error suggests obsolete options that should not be used.[1] They have "correct" settings in stalwart-mail.service, but these settings are also the implicit default, which means they are not necessary.[1]

This was patched in systemd #15812 in May, 2020.[2]

I have tested this by simply removing the values in /etc/systemd/system/stalwart-mail.service on my server, running 'daemon-reload' and restarting the service, then confirming that logs are still being written to journalctl as well as /opt/stalwart-mail/logs

[1]: <https://github.com/systemd/systemd/issues/15807#issuecomment-628528787>
[2]: <https://github.com/systemd/systemd/pull/15812>