### PR TITLE
Add Microsoft Office Macro types to bad mime types

### DIFF
--- a/resources/config/spamfilter.toml
+++ b/resources/config/spamfilter.toml
@@ -9233,6 +9233,9 @@ spam-mime = {
 "xll" = "BAD",
 "xnk" = "BAD",
 "docx" = "NZ",
+"docm" = "BAD",
+"pptm" = "BAD",
+"xlsm" = "BAD",
 "pdf" = "application/pdf|application/x-pdf|NZ",
 "pptx" = "NZ",
 "wsf" = "NZ",
@@ -9246,7 +9249,6 @@ spam-mime = {
 "xz" = "AR",
 "zip" = "AR",
 "txt" = "text/plain|message/disposition-notification|text/rfc822-headers"}
-
 
 spam-redirect = {"000d.ru",
 "0845.com",

--- a/resources/config/spamfilter/maps/mime_types.map
+++ b/resources/config/spamfilter/maps/mime_types.map
@@ -115,6 +115,9 @@ spam-mime = {
 "xll" = "BAD",
 "xnk" = "BAD",
 "docx" = "NZ",
+"docm" = "BAD",
+"pptm" = "BAD",
+"xlsm" = "BAD",
 "pdf" = "application/pdf|application/x-pdf|NZ",
 "pptx" = "NZ",
 "wsf" = "NZ",
@@ -128,4 +131,3 @@ spam-mime = {
 "xz" = "AR",
 "zip" = "AR",
 "txt" = "text/plain|message/disposition-notification|text/rfc822-headers"}
-


### PR DESCRIPTION
Since these are a rather popular infection vector, mark these files as bad.