### PR TITLE
fix: SMTP `LOGIN` authentication mechanism

### DIFF
--- a/crates/smtp/src/inbound/auth.rs
+++ b/crates/smtp/src/inbound/auth.rs
@@ -78,7 +78,7 @@ impl<T: SessionStream> Session<T> {
                 }
                 (AUTH_LOGIN, Credentials::Plain { username, secret }) => {
                     if username.is_empty() && secret.is_empty() {
-                        self.write(b"334 VXNlciBOYW1lAA==\r\n").await?;
+                        self.write(b"334 VXNlcm5hbWU6\r\n").await?;
                         return Ok(true);
                     }
                 }
@@ -115,7 +115,7 @@ impl<T: SessionStream> Session<T> {
                 (AUTH_LOGIN, Credentials::Plain { username, secret }) => {
                     return if username.is_empty() {
                         *username = response.into_string();
-                        self.write(b"334 UGFzc3dvcmQA\r\n").await?;
+                        self.write(b"334 UGFzc3dvcmQ6\r\n").await?;
                         Ok(true)
                     } else {
                         *secret = response.into_string();


### PR DESCRIPTION
This PR fixes SMTP authentication issues when using Microsoft Outlook on Windows (version 2403, build 17425.20176) in combination with the LOGIN authentication mechanism, as originally discussed [on Discord](https://discord.com/channels/923615863037390889/1233035026783010826). It might also be related to the following issues users are experiencing using various other email clients:
- https://github.com/authelia/authelia/discussions/6505
- [tagKnife on Discord: 'I had some problems trying to login with stalwart, ended up having to write a custom auth driver for stalwart LOGIN auth.'](https://discord.com/channels/923615863037390889/923616187349356545/1232382280450969681)

I have tested the change (successfully) with the following applications:
- Microsoft Outlook on Windows (version 2403, build 17425.20176)
- Microsoft Outlook on macOS (version 16.84, build 24041420)
- Apple Mail (version 16.0) on macOS (version 14.4.1)