### PR TITLE
Drop root privileges in systemd unit

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -115,7 +115,6 @@ main() {
     # Create service file
     say "🚀 Starting service..."
     if [ "${_os}" = "linux" ]; then
-        printf "\n[server.run-as]\nuser = \"stalwart-mail\"\ngroup = \"stalwart-mail\"\n" >> "$_dir/etc/config.toml"
         create_service_linux "$_dir"
     elif [ "${_os}" = "macos" ]; then
         create_service_macos "$_dir"
@@ -148,6 +147,9 @@ RestartSec=5
 ExecStart=__PATH__/bin/stalwart-mail --config=__PATH__/etc/config.toml
 PermissionsStartOnly=true
 SyslogIdentifier=stalwart-mail
+User=stalwart-mail
+Group=stalwart-mail
+AmbientCapabilities=CAP_NET_BIND_SERVICE
 
 [Install]
 WantedBy=multi-user.target

--- a/resources/systemd/stalwart-mail.service
+++ b/resources/systemd/stalwart-mail.service
@@ -14,6 +14,9 @@ RestartSec=5
 ExecStart=__PATH__/bin/stalwart-mail --config=__PATH__/etc/config.toml
 PermissionsStartOnly=true
 SyslogIdentifier=stalwart-mail
+User=stalwart-mail
+Group=stalwart-mail
+AmbientCapabilities=CAP_NET_BIND_SERVICE
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Use an ambient capability for `CAP_NET_BIND_SERVICE` to avoid dealing with special file attributes.