### PR TITLE
Privileged bind helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -518,6 +518,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "bind_helper"
+version = "0.1.0"
+dependencies = [
+ "nix 0.28.0",
+ "zerocopy",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.69.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -992,6 +1000,7 @@ dependencies = [
  "arc-swap",
  "base64 0.22.0",
  "bincode",
+ "bind_helper",
  "chrono",
  "decancer",
  "directory",
@@ -1014,7 +1023,6 @@ dependencies = [
  "opentelemetry_sdk",
  "parking_lot",
  "pem",
- "privdrop",
  "proxy-header",
  "pwhash",
  "rcgen 0.12.1",
@@ -3315,6 +3323,7 @@ dependencies = [
 name = "mail-server"
 version = "0.7.3"
 dependencies = [
+ "bind_helper",
  "common",
  "directory",
  "imap",
@@ -3322,6 +3331,7 @@ dependencies = [
  "jmap",
  "jmap_proto",
  "managesieve",
+ "privdrop",
  "smtp",
  "store",
  "tokio",
@@ -3431,6 +3441,15 @@ name = "memoffset"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
@@ -3602,8 +3621,21 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
- "memoffset",
+ "memoffset 0.7.1",
  "pin-utils",
+]
+
+[[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.5.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset 0.9.1",
 ]
 
 [[package]]
@@ -4285,7 +4317,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bc12de3935536ed9b69488faea4450a298dac44179b54f71806e63f55034bf9"
 dependencies = [
  "libc",
- "nix",
+ "nix 0.26.4",
 ]
 
 [[package]]
@@ -7202,18 +7234,19 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.32"
+version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
 dependencies = [
+ "byteorder",
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.32"
+version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "crates/utils",
     "crates/common",
     "crates/cli",
+    "crates/bind-helper",
     "tests",
 ]
 

--- a/crates/bind-helper/Cargo.toml
+++ b/crates/bind-helper/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "bind_helper"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+zerocopy = { version = "0.7.33", features = ["derive"] }
+
+[target.'cfg(unix)'.dependencies]
+nix = { version = "0.28.0", features = ["socket", "process", "net", "uio"] }

--- a/crates/bind-helper/src/addr.rs
+++ b/crates/bind-helper/src/addr.rs
@@ -1,0 +1,67 @@
+use std::net::{SocketAddr, SocketAddrV4, SocketAddrV6};
+use zerocopy::{native_endian, AsBytes, FromBytes, FromZeroes};
+
+#[derive(Default, Copy, Clone, AsBytes, FromBytes, FromZeroes)]
+#[repr(C)]
+pub struct Addr {
+    ip: [u8; 16],
+    scope_id: native_endian::U32,
+    port: native_endian::U16,
+    version: u8,
+}
+
+impl From<SocketAddr> for Addr {
+    fn from(value: SocketAddr) -> Self {
+        match value {
+            SocketAddr::V4(v4) => Addr {
+                ip: v4.ip().octets().leftpad(0),
+                scope_id: 0.into(),
+                port: v4.port().into(),
+                version: 4,
+            },
+            SocketAddr::V6(v6) => Addr {
+                ip: v6.ip().octets(),
+                scope_id: v6.scope_id().into(),
+                port: v6.port().into(),
+                version: 6,
+            },
+        }
+    }
+}
+
+impl From<Addr> for SocketAddr {
+    fn from(addr: Addr) -> Self {
+        match addr.version {
+            4 => SocketAddr::V4(SocketAddrV4::new(
+                addr.ip.unleftpad().into(),
+                addr.port.get(),
+            )),
+            6 => SocketAddr::V6(SocketAddrV6::new(
+                addr.ip.into(),
+                addr.port.get(),
+                0,
+                addr.scope_id.get(),
+            )),
+            _ => panic!(),
+        }
+    }
+}
+
+pub trait Leftpad: Copy {
+    type T: Copy;
+    fn leftpad<const N: usize>(&self, val: Self::T) -> [Self::T; N];
+    fn unleftpad<const N: usize>(&self) -> [Self::T; N];
+}
+
+impl<T: Copy, const M: usize> Leftpad for [T; M] {
+    type T = T;
+    fn leftpad<const N: usize>(&self, val: T) -> [T; N] {
+        let mut arr = [val; N];
+        let back = arr.rchunks_exact_mut(M).next().unwrap();
+        back.copy_from_slice(self);
+        arr
+    }
+    fn unleftpad<const N: usize>(&self) -> [T; N] {
+        self.rchunks_exact(M).next().unwrap().try_into().unwrap()
+    }
+}

--- a/crates/bind-helper/src/lib.rs
+++ b/crates/bind-helper/src/lib.rs
@@ -1,0 +1,10 @@
+mod addr;
+
+#[cfg(unix)]
+mod unix;
+
+#[cfg(unix)]
+pub use unix::*;
+
+#[cfg(not(unix))]
+pub struct Helper;

--- a/crates/bind-helper/src/unix.rs
+++ b/crates/bind-helper/src/unix.rs
@@ -1,0 +1,122 @@
+use crate::addr::Addr;
+
+use zerocopy::AsBytes;
+
+use std::{
+    io::{IoSlice, IoSliceMut, Read, Write},
+    net::SocketAddr,
+    os::{
+        fd::{AsRawFd, RawFd},
+        unix::net::UnixStream,
+    },
+};
+
+use nix::{
+    cmsg_space,
+    errno::Errno,
+    sys::socket::{self, ControlMessage, MsgFlags, SockaddrStorage},
+    unistd::ForkResult,
+};
+
+const BATCH_SIZE: usize = 16;
+
+fn privileged_helper(mut peer: UnixStream) {
+    let mut cmsg_buffer = cmsg_space!([RawFd; BATCH_SIZE]);
+    let mut addrs = [Addr::default(); BATCH_SIZE];
+    let mut return_values = [0; BATCH_SIZE];
+    loop {
+        let (fds, bytes) = {
+            let mut iov = [IoSliceMut::new(addrs.as_bytes_mut())];
+            let recvmsg = socket::recvmsg::<()>(
+                peer.as_raw_fd(),
+                &mut iov,
+                Some(&mut cmsg_buffer),
+                MsgFlags::empty(),
+            )
+            .unwrap();
+
+            if recvmsg.bytes == 0 {
+                break;
+            }
+
+            let fds = recvmsg.cmsgs().find_map(|cmsg| match cmsg {
+                socket::ControlMessageOwned::ScmRights(r) => Some(r),
+                _ => None,
+            });
+
+            (fds.unwrap(), recvmsg.bytes)
+        };
+
+        let addrs = &mut addrs[..fds.len()];
+        let return_values = &mut return_values[..fds.len()];
+
+        peer.read_exact(&mut addrs.as_bytes_mut()[bytes..]).unwrap();
+
+        for ((addr, fd), return_value) in addrs
+            .iter()
+            .zip(fds.iter().copied())
+            .zip(return_values.iter_mut())
+        {
+            let sockaddr = SocketAddr::from(*addr);
+            let fd = RawFd::from(fd);
+            let ret = socket::bind(fd, &SockaddrStorage::from(sockaddr));
+            *return_value = match ret {
+                Err(Errno::UnknownErrno) => i32::MAX,
+                Err(e) => e as i32,
+                Ok(()) => 0,
+            };
+            nix::unistd::close(fd).unwrap();
+        }
+
+        peer.write_all(return_values.as_bytes_mut()).unwrap();
+    }
+}
+
+#[cfg(unix)]
+pub struct Helper(UnixStream);
+
+// Safety: fork is safe if that's the first thing the main function does.
+// Especially, do not create any threads and do not modify any global state,
+// which also implys using stdin or stdout (because of buffering),
+// before this fork call. This also implies adding `#[tokio::main]` attributes
+// or similar to your inner main function instead of the real main.
+pub unsafe fn start_privileged_helper() -> Helper {
+    // The socketpair call is safe before fork. Make sure to drop
+    // the unneeded side immediately in both the child and the parent.
+    let (parent_sock, child_sock) = UnixStream::pair().unwrap();
+
+    if let ForkResult::Child = nix::unistd::fork().unwrap() {
+        drop(parent_sock);
+        privileged_helper(child_sock);
+        std::process::exit(0);
+    } else {
+        drop(child_sock);
+        Helper(parent_sock)
+    }
+}
+
+impl Helper {
+    pub fn bind_sockets(&mut self, sockets: &[(RawFd, SocketAddr)]) -> Vec<i32> {
+        let mut result = vec![i32::MAX; sockets.len()];
+        for (batch, batch_result) in sockets
+            .chunks(BATCH_SIZE)
+            .zip(result.chunks_mut(BATCH_SIZE))
+        {
+            let fds: Vec<_> = batch.iter().copied().map(|(fd, _)| fd).collect();
+            let data: Vec<_> = batch.iter().map(|&(_, addr)| Addr::from(addr)).collect();
+
+            let iov = [IoSlice::new(data.as_bytes())];
+            socket::sendmsg::<()>(
+                self.0.as_raw_fd(),
+                &iov,
+                &[ControlMessage::ScmRights(&fds[..])],
+                MsgFlags::empty(),
+                None,
+            )
+            .unwrap();
+
+            self.0.read_exact(batch_result.as_bytes_mut()).unwrap();
+        }
+        result
+    }
+}

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -58,9 +58,9 @@ bincode = "1.3.1"
 hostname = "0.4.0"
 zip = "0.6.6"
 pwhash = "1.0.0"
+bind_helper = { version = "0.1.0", path = "../bind-helper" }
 
 [target.'cfg(unix)'.dependencies]
-privdrop = "0.5.3"
 tracing-journald = "0.3"
 
 [features]

--- a/crates/common/src/manager/boot.rs
+++ b/crates/common/src/manager/boot.rs
@@ -73,7 +73,7 @@ enum ImportExport {
 }
 
 impl BootManager {
-    pub async fn init() -> Self {
+    pub async fn init(helper: Option<bind_helper::Helper>) -> Self {
         let mut config_path = std::env::var("CONFIG_PATH").ok();
         let mut import_export = ImportExport::None;
 
@@ -151,7 +151,7 @@ impl BootManager {
         let mut servers = Servers::parse(&mut config);
 
         // Bind ports and drop privileges
-        servers.bind_and_drop_priv(&mut config);
+        servers.bind_all(&mut config, helper);
 
         // Load stores
         let mut stores = Stores::parse(&mut config).await;

--- a/crates/main/Cargo.toml
+++ b/crates/main/Cargo.toml
@@ -27,6 +27,10 @@ directory = { path = "../directory" }
 utils = { path = "../utils" }
 tokio = { version = "1.23", features = ["full"] }
 tracing = "0.1"
+bind_helper = { path = "../bind-helper" }
+
+[target.'cfg(unix)'.dependencies]
+privdrop = "0.5.3"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 jemallocator = "0.5.0"

--- a/crates/main/src/main.rs
+++ b/crates/main/src/main.rs
@@ -1,104 +1,23 @@
-/*
- * Copyright (c) 2023 Stalwart Labs Ltd.
- *
- * This file is part of the Stalwart Mail Server.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- * in the LICENSE file at the top-level directory of this distribution.
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- * You can be released from the requirements of the AGPLv3 license by
- * purchasing a commercial license. Please contact licensing@stalw.art
- * for more details.
-*/
+mod unprivileged_main;
 
-use std::time::Duration;
+use utils::UnwrapFailure;
 
-use common::{config::server::ServerProtocol, manager::boot::BootManager};
-use imap::core::{ImapSessionManager, IMAP};
-use jmap::{api::JmapSessionManager, services::IPC_CHANNEL_BUFFER, JMAP};
-use managesieve::core::ManageSieveSessionManager;
-use smtp::core::{SmtpSessionManager, SMTP};
-use tokio::sync::mpsc;
-use utils::wait_for_shutdown;
+fn main() -> std::io::Result<()> {
+    let mut helper = None;
 
-#[cfg(not(target_env = "msvc"))]
-use jemallocator::Jemalloc;
+    // Drop privileges if specified. If so, start the privileged helper before that.
+    #[cfg(not(target_env = "msvc"))]
+    {
+        if let Ok(run_as_user) = std::env::var("RUN_AS_USER") {
+            helper = Some(unsafe { bind_helper::start_privileged_helper() });
 
-#[cfg(not(target_env = "msvc"))]
-#[global_allocator]
-static GLOBAL: Jemalloc = Jemalloc;
+            let mut pd = privdrop::PrivDrop::default().user(run_as_user);
+            if let Ok(run_as_group) = std::env::var("RUN_AS_GROUP") {
+                pd = pd.group(run_as_group);
+            }
+            pd.apply().failed("Failed to drop privileges");
+        }
+    }
 
-#[tokio::main]
-async fn main() -> std::io::Result<()> {
-    // Load config and apply macros
-    let init = BootManager::init().await;
-
-    // Parse core
-    let mut config = init.config;
-    let core = init.core;
-
-    // Init servers
-    let (delivery_tx, delivery_rx) = mpsc::channel(IPC_CHANNEL_BUFFER);
-    let smtp = SMTP::init(&mut config, core.clone(), delivery_tx).await;
-    let jmap = JMAP::init(&mut config, delivery_rx, core.clone(), smtp.inner.clone()).await;
-    let imap = IMAP::init(&mut config, jmap.clone()).await;
-
-    // Log configuration errors
-    config.log_errors(init.guards.is_none());
-    config.log_warnings(init.guards.is_none());
-
-    // Spawn servers
-    let shutdown_tx = init.servers.spawn(|server, acceptor, shutdown_rx| {
-        match &server.protocol {
-            ServerProtocol::Smtp | ServerProtocol::Lmtp => server.spawn(
-                SmtpSessionManager::new(smtp.clone()),
-                core.clone(),
-                acceptor,
-                shutdown_rx,
-            ),
-            ServerProtocol::Http => server.spawn(
-                JmapSessionManager::new(jmap.clone()),
-                core.clone(),
-                acceptor,
-                shutdown_rx,
-            ),
-            ServerProtocol::Imap => server.spawn(
-                ImapSessionManager::new(imap.clone()),
-                core.clone(),
-                acceptor,
-                shutdown_rx,
-            ),
-            ServerProtocol::ManageSieve => server.spawn(
-                ManageSieveSessionManager::new(imap.clone()),
-                core.clone(),
-                acceptor,
-                shutdown_rx,
-            ),
-        };
-    });
-
-    // Wait for shutdown signal
-    wait_for_shutdown(&format!(
-        "Shutting down Stalwart Mail Server v{}...",
-        env!("CARGO_PKG_VERSION")
-    ))
-    .await;
-
-    // Stop services
-    let _ = shutdown_tx.send(true);
-
-    // Wait for services to finish
-    tokio::time::sleep(Duration::from_secs(1)).await;
-
-    Ok(())
+    unprivileged_main::unprivileged_main(helper)
 }

--- a/crates/main/src/unprivileged_main.rs
+++ b/crates/main/src/unprivileged_main.rs
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2023 Stalwart Labs Ltd.
+ *
+ * This file is part of the Stalwart Mail Server.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ * in the LICENSE file at the top-level directory of this distribution.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * You can be released from the requirements of the AGPLv3 license by
+ * purchasing a commercial license. Please contact licensing@stalw.art
+ * for more details.
+*/
+
+use std::time::Duration;
+
+use common::{config::server::ServerProtocol, manager::boot::BootManager};
+use imap::core::{ImapSessionManager, IMAP};
+use jmap::{api::JmapSessionManager, services::IPC_CHANNEL_BUFFER, JMAP};
+use managesieve::core::ManageSieveSessionManager;
+use smtp::core::{SmtpSessionManager, SMTP};
+use tokio::sync::mpsc;
+use utils::wait_for_shutdown;
+
+#[cfg(not(target_env = "msvc"))]
+use jemallocator::Jemalloc;
+
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
+
+#[tokio::main]
+pub async fn unprivileged_main(helper: Option<bind_helper::Helper>) -> std::io::Result<()> {
+    // Load config and apply macros
+    let init = BootManager::init(helper).await;
+
+    // Parse core
+    let mut config = init.config;
+    let core = init.core;
+
+    // Init servers
+    let (delivery_tx, delivery_rx) = mpsc::channel(IPC_CHANNEL_BUFFER);
+    let smtp = SMTP::init(&mut config, core.clone(), delivery_tx).await;
+    let jmap = JMAP::init(&mut config, delivery_rx, core.clone(), smtp.inner.clone()).await;
+    let imap = IMAP::init(&mut config, jmap.clone()).await;
+
+    // Log configuration errors
+    config.log_errors(init.guards.is_none());
+    config.log_warnings(init.guards.is_none());
+
+    // Spawn servers
+    let shutdown_tx = init.servers.spawn(|server, acceptor, shutdown_rx| {
+        match &server.protocol {
+            ServerProtocol::Smtp | ServerProtocol::Lmtp => server.spawn(
+                SmtpSessionManager::new(smtp.clone()),
+                core.clone(),
+                acceptor,
+                shutdown_rx,
+            ),
+            ServerProtocol::Http => server.spawn(
+                JmapSessionManager::new(jmap.clone()),
+                core.clone(),
+                acceptor,
+                shutdown_rx,
+            ),
+            ServerProtocol::Imap => server.spawn(
+                ImapSessionManager::new(imap.clone()),
+                core.clone(),
+                acceptor,
+                shutdown_rx,
+            ),
+            ServerProtocol::ManageSieve => server.spawn(
+                ManageSieveSessionManager::new(imap.clone()),
+                core.clone(),
+                acceptor,
+                shutdown_rx,
+            ),
+        };
+    });
+
+    // Wait for shutdown signal
+    wait_for_shutdown(&format!(
+        "Shutting down Stalwart Mail Server v{}...",
+        env!("CARGO_PKG_VERSION")
+    ))
+    .await;
+
+    // Stop services
+    let _ = shutdown_tx.send(true);
+
+    // Wait for services to finish
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    Ok(())
+}

--- a/tests/src/imap/mod.rs
+++ b/tests/src/imap/mod.rs
@@ -280,7 +280,7 @@ async fn init_imap_tests(store_id: &str, delete_if_exists: bool) -> IMAPTest {
     let mut servers = Servers::parse(&mut config);
 
     // Bind ports and drop privileges
-    servers.bind_and_drop_priv(&mut config);
+    servers.bind_all(&mut config, None);
 
     // Build stores
     let stores = Stores::parse_all(&mut config).await;

--- a/tests/src/jmap/mod.rs
+++ b/tests/src/jmap/mod.rs
@@ -414,7 +414,7 @@ async fn init_jmap_tests(store_id: &str, delete_if_exists: bool) -> JMAPTest {
     let mut servers = Servers::parse(&mut config);
 
     // Bind ports and drop privileges
-    servers.bind_and_drop_priv(&mut config);
+    servers.bind_all(&mut config, None);
 
     // Build stores
     let stores = Stores::parse_all(&mut config).await;

--- a/tests/src/jmap/push_subscription.rs
+++ b/tests/src/jmap/push_subscription.rs
@@ -126,7 +126,7 @@ pub async fn test(params: &mut JMAPTest) {
 
     // Start JMAP server
     let manager = SessionManager::from(push_server.clone());
-    servers.bind_and_drop_priv(&mut settings);
+    servers.bind_all(&mut settings, None);
     settings.assert_no_errors();
     let _shutdown_tx = servers.spawn(|server, acceptor, shutdown_rx| {
         server.spawn(manager.clone(), mock_core.clone(), acceptor, shutdown_rx);

--- a/tests/src/smtp/outbound/mod.rs
+++ b/tests/src/smtp/outbound/mod.rs
@@ -146,7 +146,7 @@ impl TestServer {
             .retain(|server| protocols.contains(&server.protocol));
 
         // Start servers
-        servers.bind_and_drop_priv(&mut config);
+        servers.bind_all(&mut config, None);
         let instance = self.instance.clone();
         let smtp_manager = SmtpSessionManager::new(instance.clone());
         let jmap = JMAP::init(


### PR DESCRIPTION
When `RUN_AS_USER` is specified, fork off a small privileged helper that does nothing except binding to privileged ports, then immediately drop the privileges, even before starting the runtime.

The helper is small because it contains a tiny amount of code (50 "main" lines of code + 16 lines of code trivial struct mapping) and only uses 2 very basic dependencies (zerocopy and nix). This makes it very easy to audit.