### PR TITLE
Bugfix for master-user

### DIFF
--- a/crates/imap/src/op/authenticate.rs
+++ b/crates/imap/src/op/authenticate.rs
@@ -237,7 +237,7 @@ pub fn decode_challenge_plain(challenge: &[u8]) -> Result<Credentials<String>, &
     let mut arg_num = 0;
     for &ch in challenge {
         if ch != 0 {
-            if arg_num == 1 {
+            if arg_num < 2 {
                 username.push(ch);
             } else if arg_num == 2 {
                 secret.push(ch);


### PR DESCRIPTION
If the master user is separated with a \0 from the username, we need to keep the first part. Otherwise, the username is "" and login will fail.