### PR TITLE
systemd/service: remove unused and deprecated PermissionsStartOnly

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -145,7 +145,6 @@ KillSignal=SIGINT
 Restart=on-failure
 RestartSec=5
 ExecStart=__PATH__/bin/stalwart-mail --config=__PATH__/etc/config.toml
-PermissionsStartOnly=true
 SyslogIdentifier=stalwart-mail
 User=stalwart-mail
 Group=stalwart-mail

--- a/resources/systemd/stalwart-mail.service
+++ b/resources/systemd/stalwart-mail.service
@@ -12,7 +12,6 @@ KillSignal=SIGINT
 Restart=on-failure
 RestartSec=5
 ExecStart=__PATH__/bin/stalwart-mail --config=__PATH__/etc/config.toml
-PermissionsStartOnly=true
 SyslogIdentifier=stalwart-mail
 User=stalwart-mail
 Group=stalwart-mail


### PR DESCRIPTION
This setting has been deprecated in systemd 240.

It didn't seem to be actually useful since there's no `Exec*` other
than ExecStart being defined here.
