### PR TITLE
POP3 QUIT must write a response

### DIFF
--- a/crates/pop3/src/op/delete.rs
+++ b/crates/pop3/src/op/delete.rs
@@ -89,6 +89,11 @@ impl<T: SessionStream> Session<T> {
                         self.write_err("Failed to delete messages").await?;
                     }
                 }
+            } else {
+                self.write_ok(format!(
+                    "Stalwart POP3 bids you farewell (no messages deleted)."
+                ))
+                .await?;
             }
         } else {
             self.write_ok("Stalwart POP3 bids you farewell.").await?;


### PR DESCRIPTION
I verified that I can set the `pop3_polling_enabled` discourse setting (which immediately checks that it can connect and authenticate with the POP3 server). I also verified that discourse's polling doesn't cause any errors to be logged, though haven't verified that discourse receiving emails actually works (I have other discourse config problems I need to fix first).

Fixes: #567