### PR TITLE
Faster export and ignore blob download errors

### DIFF
--- a/crates/cli/src/modules/export.rs
+++ b/crates/cli/src/modules/export.rs
@@ -82,34 +82,36 @@ impl ExportCommands {
                     let mut blob_path = path.clone();
                     blob_path.push(&blob_id);
 
-                    futures.push(async move {
-                        let mut retry_count = 0;
+                    if !tokio::fs::metadata(&blob_path).await.is_ok() {
+                        futures.push(async move {
+                            let mut retry_count = 0;
 
-                        let bytes = loop {
-                            match client.download(&blob_id).await {
-                                Ok(bytes) => break bytes,
-                                Err(_) if retry_count < RETRY_ATTEMPTS => {
-                                    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-                                    retry_count += 1;
+                            let bytes = loop {
+                                match client.download(&blob_id).await {
+                                    Ok(bytes) => break bytes,
+                                    Err(_) if retry_count < RETRY_ATTEMPTS => {
+                                        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                                        retry_count += 1;
+                                    }
+                                    result => {
+                                        result.unwrap_or_else(|_| vec![]);
+                                        break vec![];
+                                    }
                                 }
-                                result => {
-                                    result.unwrap_result("download blob");
-                                    return;
-                                }
-                            }
-                        };
+                            };
 
-                        tokio::fs::OpenOptions::new()
-                            .create(true)
-                            .write(true)
-                            .truncate(true)
-                            .open(&blob_path)
-                            .await
-                            .unwrap_result(&format!("open {}", blob_path.display()))
-                            .write_all(&bytes)
-                            .await
-                            .unwrap_result(&format!("write {}", blob_path.display()));
-                    });
+                            tokio::fs::OpenOptions::new()
+                                .create(true)
+                                .write(true)
+                                .truncate(true)
+                                .open(&blob_path)
+                                .await
+                                .unwrap_result(&format!("open {}", blob_path.display()))
+                                .write_all(&bytes)
+                                .await
+                                .unwrap_result(&format!("write {}", blob_path.display()));
+                        });
+                    };
 
                     if futures.len() == num_concurrent {
                         futures.next().await.unwrap();

--- a/crates/imap/src/op/authenticate.rs
+++ b/crates/imap/src/op/authenticate.rs
@@ -229,7 +229,7 @@ pub fn decode_challenge_plain(challenge: &[u8]) -> Result<Credentials<String>, &
     let mut arg_num = 0;
     for &ch in challenge {
         if ch != 0 {
-            if arg_num == 1 {
+            if arg_num < 2 {
                 username.push(ch);
             } else if arg_num == 2 {
                 secret.push(ch);


### PR DESCRIPTION
When exporting, check first if the blob has already been exported earlier, that is if it already exists on the disk. Only download the blob if not.

Continue exporting even if a blob does not exist or cannot be downloaded.

```rust
-                                    result.unwrap_result("download blob");
-                                    return;
+                                    result.unwrap_or_else(|_| vec![]);
+                                    break vec![];
```