### PR TITLE
Bind Auth result not respected in LDAP backend

### DIFF
--- a/crates/directory/src/backend/ldap/lookup.rs
+++ b/crates/directory/src/backend/ldap/lookup.rs
@@ -68,7 +68,7 @@ impl LdapDirectory {
 
                     ldap3::drive!(conn);
 
-                    ldap.simple_bind(&auth_bind.build(username), secret).await?;
+                    ldap.simple_bind(&auth_bind.build(username), secret).await?.success()?;
 
                     match self
                         .find_principal(&mut ldap, &self.mappings.filter_name.build(username))

--- a/crates/directory/src/backend/ldap/pool.rs
+++ b/crates/directory/src/backend/ldap/pool.rs
@@ -22,7 +22,7 @@ impl managed::Manager for LdapConnectionManager {
         ldap3::drive!(conn);
 
         if let Some(bind) = &self.bind_dn {
-            ldap.simple_bind(&bind.dn, &bind.password).await?;
+            ldap.simple_bind(&bind.dn, &bind.password).await?.success()?;
         }
 
         Ok(ldap)


### PR DESCRIPTION
This pull request is not intended to be merged directly. I just want to raise the author's attention that there are some issues in error handling in the LDAP backend that need to be reviewed and fixed, as indicated in issue [514](https://github.com/stalwartlabs/mail-server/issues/514). These issues might create some security vulnerabilities.