### PR TITLE
Fix off-by-one error in get_blob with Range

### DIFF
--- a/crates/store/src/dispatch/blob.rs
+++ b/crates/store/src/dispatch/blob.rs
@@ -75,7 +75,7 @@ impl BlobStore {
             _ => return result,
         };
 
-        if range.end >= decompressed.len() {
+        if range.end > decompressed.len() {
             Ok(Some(decompressed))
         } else {
             Ok(Some(


### PR DESCRIPTION
When `range.end == decompressed.len()`, the last value in the range will also be the last value in `decompressed`, because ranges ends are exclusive.

This issue had two consequences that I have noticed. The first is that requesting the last (or only) message part via JMAP will result in the entire message being returned instead, because the range ends on the last byte of the message.

The second issue, which resulted from the first, was that attempting to fetch the last (or only) message part would almost always fail when requested via JMAP if the message part used the quoted-printable transfer encoding. This is because Stalwart would attempt to decode the blob, but since the entire file was returned, this would include headers which are very likely to break assumptions made by the decoder, e.g. unexpected '=' tokens as in 'charset=UTF-8'

The second issue was originally reported here:
https://github.com/stalwartlabs/mail-server/discussions/758