### PR TITLE
Allow compilation without enterprise feature

### DIFF
--- a/crates/jmap/src/api/http.rs
+++ b/crates/jmap/src/api/http.rs
@@ -33,8 +33,10 @@ use jmap_proto::{
 };
 use std::future::Future;
 
+#[cfg(feature = "enterprise")]
+use crate::api::management::enterprise::telemetry::TelemetryApi;
+
 use crate::{
-    api::management::enterprise::telemetry::TelemetryApi,
     auth::{
         authenticate::{Authenticator, HttpHeaders},
         oauth::{

--- a/crates/jmap/src/api/management/mod.rs
+++ b/crates/jmap/src/api/management/mod.rs
@@ -23,6 +23,7 @@ use common::{auth::AccessToken, Server};
 use directory::{backend::internal::manage, Permission};
 use dkim::DkimManagement;
 use dns::DnsManagement;
+#[cfg(feature = "enterprise")]
 use enterprise::telemetry::TelemetryApi;
 use hyper::Method;
 use log::LogManagement;

--- a/crates/jmap/src/api/management/stores.rs
+++ b/crates/jmap/src/api/management/stores.rs
@@ -27,7 +27,9 @@ use crate::{
     services::index::Indexer,
 };
 
-use super::{decode_path_element, enterprise::undelete::UndeleteApi};
+use super::decode_path_element;
+#[cfg(feature = "enterprise")]
+use super::enterprise::undelete::UndeleteApi;
 use std::future::Future;
 
 pub trait ManageStore: Sync + Send {


### PR DESCRIPTION
Currently, when building with `--no-default-features`, compilation fails.