### PR TITLE
Allow to search using bind dn even when bind auth is enabled

### DIFF
--- a/crates/directory/src/backend/ldap/config.rs
+++ b/crates/directory/src/backend/ldap/config.rs
@@ -12,7 +12,7 @@ use utils::config::{utils::AsKey, Config};
 
 use crate::core::config::build_pool;
 
-use super::{Bind, LdapConnectionManager, LdapDirectory, LdapFilter, LdapMappings};
+use super::{AuthBind, Bind, LdapConnectionManager, LdapDirectory, LdapFilter, LdapMappings};
 
 impl LdapDirectory {
     pub fn from_config(config: &mut Config, prefix: impl AsKey, data_store: Store) -> Option<Self> {
@@ -107,7 +107,11 @@ impl LdapDirectory {
             .property_or_default::<bool>((&prefix, "bind.auth.enable"), "false")
             .unwrap_or_default()
         {
-            LdapFilter::from_config(config, (&prefix, "bind.auth.dn")).into()
+            let filter = LdapFilter::from_config(config, (&prefix, "bind.auth.dn"));
+            let search = config
+                .property_or_default::<bool>((&prefix, "bind.auth.search"), "true")
+                .unwrap_or(true);
+            Some(AuthBind { filter, search })
         } else {
             None
         };

--- a/crates/directory/src/backend/ldap/mod.rs
+++ b/crates/directory/src/backend/ldap/mod.rs
@@ -15,7 +15,7 @@ pub mod pool;
 pub struct LdapDirectory {
     pool: Pool<LdapConnectionManager>,
     mappings: LdapMappings,
-    auth_bind: Option<LdapFilter>,
+    auth_bind: Option<AuthBind>,
     pub(crate) data_store: Store,
 }
 
@@ -75,4 +75,9 @@ impl Bind {
     pub fn new(dn: String, password: String) -> Self {
         Self { dn, password }
     }
+}
+
+pub(crate) struct AuthBind {
+    filter: LdapFilter,
+    search: bool,
 }


### PR DESCRIPTION
This adds compatibility for cases when auth bind doesn't expose some required attributes, but the admin bind does (e.g. [kanidm](https://kanidm.github.io/kanidm/stable/integrations/ldap.html?search=self_#access-controls))

Note: naming might need some work