### PR TITLE
A couple of small fixes in the recently-added Azure blob storage support

### DIFF
--- a/crates/store/src/backend/azure/mod.rs
+++ b/crates/store/src/backend/azure/mod.rs
@@ -32,7 +32,7 @@ impl AzureStore {
         let container = config.value_require((&prefix, "container"))?.to_string();
 
         let credentials = match (
-            config.value((&prefix, "access-key")),
+            config.value((&prefix, "azure-access-key")),
             config.value((&prefix, "sas-token")),
         ) {
             (Some(access_key), None) => {
@@ -53,7 +53,7 @@ impl AzureStore {
                     prefix.as_str(),
                     concat!(
                         "Failed to create credentials: exactly one of ",
-                        "'access-key' and 'sas-token' must be specified"
+                        "'azure-access-key' and 'sas-token' must be specified"
                     ),
                 );
                 return None;
@@ -126,6 +126,7 @@ impl AzureStore {
                             }
                             Err(e) => {
                                 err = Some(e);
+                                break;
                             }
                         }
                     }


### PR DESCRIPTION
This is a followup to https://github.com/stalwartlabs/mail-server/pull/907

I was working on the webadmin changes, and I realized that the way that webadmin works, there's only one field in the form that is named "access-key". If we try to use that one field from both the Azure and the S3 back ends, yes, the field will get hidden and un-hidden based on what type of store we're adding. But it's still the same field.

This is not wonderful, because in the case of S3, "access-key" is not particularly secret. It's the "login name", if you will, not the "password". But Azure uses the same terminology to refer to what is, in effect, the "password". And we really want to display those two types of things differently from each other. The non-secret "access key" in S3 should be displayed as a regular text input field; the secret "access key" in Azure should be displayed as a password-type field.

We can't change the name of the field used by S3, because that would be a breaking change. But we can change the name of the field used by Azure. This PR makes the Azure back end use the config field name "azure-access-key" instead of "access-key".