### PR TITLE
Introducing Stalwart Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@
   <a href="https://www.gnu.org/licenses/agpl-3.0"><img src="https://img.shields.io/badge/License-AGPL_v3-blue.svg?label=license&style=flat-square" alt="License: AGPL v3"></a>
   &nbsp;
   <a href="https://stalw.art/docs/get-started/"><img src="https://img.shields.io/badge/read_the-docs-red?style=flat-square" alt="Documentation"></a>
+  &nbsp;
+  <a href="https://gurubase.io/g/stalwart"><img src="https://img.shields.io/badge/Gurubase-Ask%20Stalwart%20Guru-006BFF?style=flat-square" alt="Gurubase"></a>
 </p>
 <p align="center">
   <a href="https://mastodon.social/@stalwartlabs"><img src="https://img.shields.io/mastodon/follow/109929667531941122?style=flat-square&logo=mastodon&color=%236364ff&label=Follow%20on%20Mastodon" alt="Mastodon"></a>


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Stalwart Guru](https://gurubase.io/g/stalwart) to Gurubase. Stalwart Guru uses the data from this repo and data from the [docs](https://stalw.art/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Stalwart Guru", which highlights that Stalwart now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Stalwart Guru in Gurubase, just let me know that's totally fine.
