### PR TITLE
Fix macro detection in DNS record generation

### DIFF
--- a/crates/jmap/src/api/management/dns.rs
+++ b/crates/jmap/src/api/management/dns.rs
@@ -97,7 +97,7 @@ impl DnsManagement for Server {
                 }
                 _ => (),
             }
-            if !has_macros && value.contains("%%{") {
+            if !has_macros && value.contains("%{") {
                 has_macros = true;
             }
             keys.keys.insert(key, value);


### PR DESCRIPTION
I recently wanted to view my DNS Records in the web interface but
ran into the same issue I described in #666, where macros in signatures
were not resolved. It seems like the fix that was introduced back then has a small typo
causing them to not be recognized as macros. This contains the fix.
