### PR TITLE
Remove invalid component from SPF records

### DIFF
--- a/crates/jmap/src/api/management/dns.rs
+++ b/crates/jmap/src/api/management/dns.rs
@@ -148,13 +148,13 @@ impl DnsManagement for Server {
             records.push(DnsRecord {
                 typ: "TXT".to_string(),
                 name: format!("{server_name}."),
-                content: "v=spf1 a ra=postmaster -all".to_string(),
+                content: "v=spf1 a -all".to_string(),
             });
         }
         records.push(DnsRecord {
             typ: "TXT".to_string(),
             name: format!("{domain_name}."),
-            content: "v=spf1 mx ra=postmaster -all".to_string(),
+            content: "v=spf1 mx -all".to_string(),
         });
 
         let mut has_https = false;


### PR DESCRIPTION
This change is to remove the invalid Return Address (ra) component in the SPF record generation.
Specification is here:
http://www.open-spf.org/SPF_Record_Syntax/