### PR TITLE
Update lib features & Add cosign to binary and image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
     needs: [linux]
     if: github.event_name == 'push' || inputs.Docker
     steps:
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
       - name: Log In to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -82,6 +85,8 @@ jobs:
           echo "GHCR_DIGEST_SHA=$(cat GHCR_DIGEST_SHA)" | tee -a "${GITHUB_ENV}"
           docker buildx imagetools inspect --format '{{json .Manifest}}' index.docker.io/${{github.repository}}:$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' ${{ runner.temp }}/${{matrix.variant}}/bake-meta.json) | jq -r '.digest' > DOCKERHUB_DIGEST_SHA
           echo "DOCKERHUB_DIGEST_SHA=$(cat DOCKERHUB_DIGEST_SHA)" | tee -a "${GITHUB_ENV}"
+          cosign sign --yes $(jq --arg GHCR_DIGEST_SHA "$(cat GHCR_DIGEST_SHA)" -cr '.target."docker-metadata-action".tags | map(select(startswith("ghcr.io/${{github.repository}}")) | . + "@" + $GHCR_DIGEST_SHA) | join(" ")' ${{ runner.temp }}/${{matrix.variant}}/bake-meta.json)
+          cosign sign --yes $(jq --arg DOCKERHUB_DIGEST_SHA "$(cat DOCKERHUB_DIGEST_SHA)" -cr '.target."docker-metadata-action".tags | map(select(startswith("index.docker.io/${{github.repository}}")) | . + "@" + $DOCKERHUB_DIGEST_SHA) | join(" ")' ${{ runner.temp }}/${{matrix.variant}}/bake-meta.json)
 
       - name: Attest GHCR
         uses: actions/attest-build-provenance@v2
@@ -334,7 +339,7 @@ jobs:
         run: |
           rustup target add ${{matrix.target}}
           # Get latest FoundationDB installer
-          curl -Lo foundationdb.pkg "https://glare.now.sh/apple/foundationdb/${{startsWith(matrix.target, 'x86') && 'x86_64' || 'arm64'}}.pkg"
+          curl --retry 5 -Lso foundationdb.pkg "$(curl --retry 5 -Ls 'https://api.github.com/repos/apple/foundationdb/releases' | jq -r '.[] | select(.prerelease == false) | .assets[] | select(.name | test("${{startsWith(matrix.target, 'x86') && 'x86_64' || 'arm64'}}" + ".pkg")) | .browser_download_url' | head -n1)"
           sudo installer -allowUntrusted -dumplog -pkg foundationdb.pkg -target /
           cargo build --release --target ${{matrix.target}} -p mail-server --no-default-features --features "foundationdb elastic s3 redis enterprise"
           mkdir -p artifacts
@@ -405,16 +410,25 @@ jobs:
             archive/**/*.tar.gz
             archive/**/*.zip
 
+      - name: Use cosign to sign existing artifacts
+        uses: sigstore/gh-action-sigstore-python@v3.0.0
+        with:
+          inputs: |
+            archive/**/*.tar.gz
+            archive/**/*.zip
+
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
           files: |
             archive/**/*.tar.gz
             archive/**/*.zip
+            archive/**/*.sigstore.json
           prerelease: ${{!startsWith(github.ref, 'refs/tags/') || null}}
           tag_name: ${{!startsWith(github.ref, 'refs/tags/') && 'nightly' || null}}
           append_body: true
+          # TODO add instructions about using cosign to verify binary artifact
           body: |
             <hr />
 
-            ## Check binary attestation at [here](${{ steps.attest.outputs.attestation-url }})
+            ### Check binary attestation at [here](${{ steps.attest.outputs.attestation-url }})

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -14,24 +14,20 @@ ENV DEBIAN_FRONTEND="noninteractive" \
     TERM=xterm-256color
 # With zig, we only need libclang and make
 RUN \
-  --mount=type=cache,target=/var/cache/apt,sharing=locked \
-  --mount=type=cache,target=/var/lib/apt,sharing=locked \
-  rm -f /etc/apt/apt.conf.d/docker-clean && \
-  echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' >/etc/apt/apt.conf.d/keep-cache && \
-  apt-get update && \
-  apt-get install -yq --no-install-recommends curl jq xz-utils make libclang-16-dev
+    --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    rm -f /etc/apt/apt.conf.d/docker-clean && \
+    echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' >/etc/apt/apt.conf.d/keep-cache && \
+    apt-get update && \
+    apt-get install -yq --no-install-recommends curl jq xz-utils make libclang-16-dev
 # Install zig
-RUN ZIG_VERSION=$(curl --retry 5 -sL "https://api.github.com/repos/ziglang/zig/releases/latest" | jq -r '.tag_name') && \
+RUN \
+    ZIG_VERSION=$(curl --retry 5 -sL "https://api.github.com/repos/ziglang/zig/releases/latest" | jq -r '.tag_name') && \
     [ ! -z "$ZIG_VERSION" ] && \
     curl --retry 5 -Ls "https://ziglang.org/download/${ZIG_VERSION}/zig-linux-$(uname -m)-${ZIG_VERSION}.tar.xz" | tar -J -x -C /usr/local && \
     ln -s "/usr/local/zig-linux-$(uname -m)-${ZIG_VERSION}/zig" /usr/local/bin/zig
 # Install cargo-binstall
 RUN curl --retry 5 -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
-# Install FoundationDB
-# TODO According to https://github.com/apple/foundationdb/issues/11448#issuecomment-2417766293
-# Once FoundationDB v7.3.53 gets released, we should be able to build the aarch64-unknown-linux-gnu target.
-# The last command is for future build use, so if you are building on a native arm64 device, please use docker qemu.
-RUN curl --retry 5 -Lso /usr/lib/libfdb_c.so "$(curl --retry 5 -Ls 'https://api.github.com/repos/apple/foundationdb/releases' | jq --arg arch "$(uname -m)" -r '.[] | select(.prerelease == false) | .assets[] | select(.name | test("libfdb_c." + $arch + ".so")) | .browser_download_url' | head -n1)"
 # Install cargo-chef & sccache & cargo-zigbuild
 RUN cargo binstall --no-confirm cargo-chef sccache cargo-zigbuild
 
@@ -55,24 +51,31 @@ ARG BUILD_ENV
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Install toolchain and specify some env variables
 RUN \
-  rustup set profile minimal && \
-  rustup target add ${TARGET} && \
-  mkdir -p artifact && \
-  touch /env-cargo && \
-  if [ ! -z "${BUILD_ENV}" ]; then \
-      echo "export ${BUILD_ENV}" >> /env-cargo; \
-      echo "Setting up ${BUILD_ENV}"; \
-  fi
+    rustup set profile minimal && \
+    rustup target add ${TARGET} && \
+    mkdir -p artifact && \
+    touch /env-cargo && \
+    if [ ! -z "${BUILD_ENV}" ]; then \
+        echo "export ${BUILD_ENV}" >> /env-cargo; \
+        echo "Setting up ${BUILD_ENV}"; \
+    fi && \
+    if [[ "${TARGET}" == *gnu ]]; then \
+        echo "export FDB_ARCH=${TARGET%%-*}" >> /env-cargo; \
+    fi
+# Install FoundationDB
+RUN \
+    source /env-cargo && \
+    if [ ! -z "${FDB_ARCH}" ]; then \
+        curl --retry 5 -Lso /usr/lib/libfdb_c.so "$(curl --retry 5 -Ls 'https://api.github.com/repos/apple/foundationdb/releases' | jq --arg FDB_ARCH "$FDB_ARCH" -r '.[] | select(.prerelease == false) | .assets[] | select(.name | test("libfdb_c." + $FDB_ARCH + ".so")) | .browser_download_url' | head -n1)"; \
+    fi
 # Cargo-chef Cache layer
 RUN \
     --mount=type=secret,id=ACTIONS_CACHE_URL,env=ACTIONS_CACHE_URL \
     --mount=type=secret,id=ACTIONS_RUNTIME_TOKEN,env=ACTIONS_RUNTIME_TOKEN \
     --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
-    # TODO According to https://github.com/apple/foundationdb/issues/11448#issuecomment-2417766293
-    # Once FoundationDB v7.3.53 gets released, we should be able to build the aarch64-unknown-linux-gnu target.
     source /env-cargo && \
-    if [ "${TARGET}" = "x86_64-unknown-linux-gnu" ]; then \
+    if [ ! -z "${FDB_ARCH}" ]; then \
         RUSTFLAGS="-L /usr/lib" cargo chef cook --recipe-path recipe.json --zigbuild --release --target ${TARGET} -p mail-server --no-default-features --features "foundationdb elastic s3 redis enterprise"; \
     fi
 RUN \
@@ -87,16 +90,14 @@ RUN \
 COPY . .
 ENV RUSTC_WRAPPER="sccache" \
     SCCACHE_GHA_ENABLED=true
-# Build foundationdb version
+# Build FoundationDB version
 RUN \
     --mount=type=secret,id=ACTIONS_CACHE_URL,env=ACTIONS_CACHE_URL \
     --mount=type=secret,id=ACTIONS_RUNTIME_TOKEN,env=ACTIONS_RUNTIME_TOKEN \
     --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
-    # TODO According to https://github.com/apple/foundationdb/issues/11448#issuecomment-2417766293
-    # Once FoundationDB v7.3.53 gets released, we should be able to build the aarch64-unknown-linux-gnu target.
     source /env-cargo && \
-    if [ "${TARGET}" = "x86_64-unknown-linux-gnu" ]; then \
+    if [ ! -z "${FDB_ARCH}" ]; then \
         RUSTFLAGS="-L /usr/lib" cargo zigbuild --release --target ${TARGET} -p mail-server --no-default-features --features "foundationdb elastic s3 redis enterprise"; \
         mv /app/target/${TARGET}/release/stalwart-mail /app/artifact/stalwart-mail-foundationdb; \
     fi

--- a/crates/store/Cargo.toml
+++ b/crates/store/Cargo.toml
@@ -9,7 +9,7 @@ utils = { path = "../utils" }
 nlp = { path = "../nlp" }
 trc = { path = "../trc" }
 rocksdb = { version = "0.23", optional = true, features = ["multi-threaded-cf"] }
-foundationdb = { version = "0.9.0", features = ["embedded-fdb-include", "fdb-7_1"], optional = true }
+foundationdb = { version = "0.9.2", features = ["embedded-fdb-include", "fdb-7_3"], optional = true }
 rusqlite = { version = "0.32", features = ["bundled"], optional = true }
 rust-s3 = { version = "=0.35.0-alpha.2", default-features = false, features = ["tokio-rustls-tls", "no-verify-ssl"], optional = true }
 azure_core = { version = "0.21.0", optional = true }


### PR DESCRIPTION
This PR finishes building arm64 fdb-variant server as the FoundationDB latest stable release includes the libfdb_c_aarch64.so file.

I also noticed that foundationdb crate has a feature `fdb-7_3` since `0.9.0`.

~~Maybe we should consider deprecating the `fdb-7_1` feature some day.~~

These 2 features seems conflicting each other when building. Since it's using `libfdb_c_$ARCH.so` released in 7.3.x, I think it's better to keep the support of `fdb-7_3`.

<hr />

There's also something I want to discuss regarding the last CI refactor.

But I'm not sure whether we should talk it 
- [ ] here
- [ ] in previous PR
- [x] open a new discussion page