### PR TITLE
Add description to ID token

### DIFF
--- a/crates/common/src/auth/oauth/oidc.rs
+++ b/crates/common/src/auth/oauth/oidc.rs
@@ -92,6 +92,10 @@ pub struct StandardClaims {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     pub email: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub description: Option<String>,
 }
 
 impl Server {

--- a/crates/http/src/auth/oauth/token.rs
+++ b/crates/http/src/auth/oauth/token.rs
@@ -329,6 +329,7 @@ impl TokenHandler for Server {
                         nonce,
                         preferred_username: access_token.name.clone().into(),
                         email: access_token.emails.first().cloned(),
+                        description: access_token.description.clone().into(),
                     },
                 ) {
                     Ok(id_token) => Some(id_token),


### PR DESCRIPTION
I'm using Stalwart as IdP for my Nextcloud installation. I want the users to be created with a Displayname (Nextcloud) from the name field in Stalwart. 