### PR TITLE
fix constant updating of internal description when external account d…

### DIFF
--- a/crates/directory/src/core/principal.rs
+++ b/crates/directory/src/core/principal.rs
@@ -370,7 +370,7 @@ impl Principal {
     pub fn update_external(&mut self, mut external: Principal) -> Vec<PrincipalUpdate> {
         let mut updates = Vec::new();
         if let Some(name) = external.take_str(PrincipalField::Description) {
-            if self.get_str(PrincipalField::Description) != Some(name.as_str()) {
+            if self.get_str(PrincipalField::Description) != Some(name.as_str()).filter(|s| !s.is_empty()) {
                 updates.push(PrincipalUpdate::set(
                     PrincipalField::Description,
                     PrincipalValue::String(name.clone()),


### PR DESCRIPTION
This actually solves the
```
Error: ci@test.bixilon.de[81]: LOGIN failed: 81.1 NO [CONTACTADMIN] Another process has modified the value
```

error in https://github.com/stalwartlabs/mail-server/discussions/1236.

My SQL query looked something like:
```
SELECT ..., "" as description
FROM ...
```


This made stalwart "sync" the external description all the time to the internal directory and somehow racing it. It is still not ideal (the error should be avoided somehow else) but it reduces the chance to error massively.