### PR TITLE
move trivial tenant statements out of SPDX licence block

### DIFF
--- a/crates/jmap/src/api/management/principal.rs
+++ b/crates/jmap/src/api/management/principal.rs
@@ -254,11 +254,11 @@ impl PrincipalManager for Server {
                     })?;
                 }
 
+                let mut tenant = access_token.tenant.map(|t| t.id);
+                
                 // SPDX-SnippetBegin
                 // SPDX-FileCopyrightText: 2020 Stalwart Labs Ltd <hello@stalw.art>
                 // SPDX-License-Identifier: LicenseRef-SEL
-
-                let mut tenant = access_token.tenant.map(|t| t.id);
 
                 #[cfg(feature = "enterprise")]
                 if self.core.is_enterprise_edition() {

--- a/crates/jmap/src/api/management/queue.rs
+++ b/crates/jmap/src/api/management/queue.rs
@@ -126,13 +126,14 @@ impl QueueManagement for Server {
         access_token: &AccessToken,
     ) -> trc::Result<HttpResponse> {
         let params = UrlParams::new(req.uri().query());
+        
+        // Limit to tenant domains
+        let mut tenant_domains: Option<Vec<String>> = None;
 
         // SPDX-SnippetBegin
         // SPDX-FileCopyrightText: 2020 Stalwart Labs Ltd <hello@stalw.art>
         // SPDX-License-Identifier: LicenseRef-SEL
 
-        // Limit to tenant domains
-        let mut tenant_domains: Option<Vec<String>> = None;
         #[cfg(feature = "enterprise")]
         if self.core.is_enterprise_edition() {
             if let Some(tenant) = access_token.tenant {

--- a/crates/jmap/src/api/management/report.rs
+++ b/crates/jmap/src/api/management/report.rs
@@ -51,12 +51,13 @@ impl ManageReports for Server {
         path: Vec<&str>,
         access_token: &AccessToken,
     ) -> trc::Result<HttpResponse> {
+        // Limit to tenant domains
+        let mut tenant_domains: Option<Vec<String>> = None;
+        
         // SPDX-SnippetBegin
         // SPDX-FileCopyrightText: 2020 Stalwart Labs Ltd <hello@stalw.art>
         // SPDX-License-Identifier: LicenseRef-SEL
 
-        // Limit to tenant domains
-        let mut tenant_domains: Option<Vec<String>> = None;
         #[cfg(feature = "enterprise")]
         if self.core.is_enterprise_edition() {
             if let Some(tenant) = access_token.tenant {


### PR DESCRIPTION
Otherwise it will not build when removing all SEL licenced code parts


I am not entirely sure about the licence as questioned here https://github.com/stalwartlabs/mail-server/issues/783.

I am just creating a foss branch with all non open source code removed and those 3 statements are pretty trivial and need to be in there when building without it.