### PR TITLE
fix: enable edns0 for system resolver by default

### DIFF
--- a/crates/common/src/config/smtp/resolver.rs
+++ b/crates/common/src/config/smtp/resolver.rs
@@ -109,6 +109,10 @@ impl Resolvers {
             "quad9-tls" => (ResolverConfig::quad9_tls(), ResolverOpts::default()),
             "google" => (ResolverConfig::google(), ResolverOpts::default()),
             "system" => read_system_conf()
+                .map(|(conf, mut opts)| {
+                    opts.edns0 = true;
+                    (conf, opts)
+                })
                 .map_err(|err| {
                     config.new_build_error(
                         "resolver.type",


### PR DESCRIPTION
This fix is not entirely correct, as system resolver might not support edns0, and this flag should be read from resolv.conf.

However, we expect system resolver to support dnssec, and it is unusual for dns server to support dnssec, and not support edns0?
Also system resolver is not default in stalwart mail server, and it wouldn't be expected for user to replace secure default dns server with insecure system resolver in this case?

In any case, this should be removed after hickory-resolver is updated with this fix applied: https://github.com/hickory-dns/hickory-dns/pull/2831

And I believe it would be good for it to be always enabled in meantime.

Fixes: https://github.com/stalwartlabs/mail-server/issues/1255