### PR TITLE
Remove version disclosure pre-auth for security hardening on IMAP and ManageSieve

### DIFF
--- a/crates/imap/src/op/logout.rs
+++ b/crates/imap/src/op/logout.rs
@@ -15,12 +15,7 @@ impl<T: SessionStream> Session<T> {
         let op_start = Instant::now();
 
         let mut response = StatusResponse::bye(
-            concat!(
-                "Stalwart IMAP4rev2 v",
-                env!("CARGO_PKG_VERSION"),
-                " bids you farewell."
-            )
-            .to_string(),
+                "Stalwart IMAP4rev2 bids you farewell.",
         )
         .into_bytes();
 

--- a/crates/managesieve/src/op/logout.rs
+++ b/crates/managesieve/src/op/logout.rs
@@ -16,11 +16,8 @@ impl<T: AsyncRead + AsyncWrite> Session<T> {
             Elapsed = trc::Value::Duration(0)
         );
 
-        Ok(StatusResponse::ok(concat!(
-            "Stalwart ManageSieve v",
-            env!("CARGO_PKG_VERSION"),
-            " bids you farewell."
-        ))
+        Ok(StatusResponse::ok("Stalwart ManageSieve bids you farewell.")
+
         .into_bytes())
     }
 }


### PR DESCRIPTION
Exposing server version information before authentication increases the attack surface by aiding fingerprinting and vulnerability targeting. This change aligns with OWASP and CIS best practices for minimizing information disclosure.

This version is leaked in both IMAP and ManageSieve when issuing a LOGOUT command to either.

This PR removes the version from the logout messages in both listeners.