### PR TITLE
Add license details to OpenAPI schema

### DIFF
--- a/api/v1/openapi.yml
+++ b/api/v1/openapi.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 Stalwart Labs Ltd <hello@stalw.art>
+#
+# SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-SEL
+
 openapi: 3.0.0
 info:
   title: Stalwart Mail Server API


### PR DESCRIPTION
This would make it easier for 3rd parties to integrate with Stalwart by being clear about licensing. I'm not sure if you want this license or want to release this file specifically under a more permissive license (MIT license would make sense here in my opinion, because it's just an API schema).