### PR TITLE
fix wrong c++ std version

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[env]
+CXXFLAGS = "--std=c++20"


### PR DESCRIPTION
by default it tries to build librocksdb-sys with --std=c++17 but that fails because `uint64_t` is not defined. it is in c++20