### PR TITLE
crates/main/Cargo.toml: removed trailing spaces

### DIFF
--- a/crates/main/Cargo.toml
+++ b/crates/main/Cargo.toml
@@ -54,12 +54,12 @@ nats = ["store/nats"]
 azure = ["store/azure"]
 zenoh = ["store/zenoh"]
 kafka = ["store/kafka"]
-enterprise = [ "jmap/enterprise", 
-               "smtp/enterprise", 
-               "common/enterprise", 
-               "store/enterprise", 
-               "managesieve/enterprise", 
-               "directory/enterprise", 
+enterprise = [ "jmap/enterprise",
+               "smtp/enterprise",
+               "common/enterprise",
+               "store/enterprise",
+               "managesieve/enterprise",
+               "directory/enterprise",
                "email/enterprise",
                "spam-filter/enterprise",
                "http/enterprise",


### PR DESCRIPTION
Those trailing spaces where found by my text editor while working on that file.

Reason for this patch is two-fold:
* Upcoming patches will be without sneaking this change in
* Preventing repeating reverting the white space change each time my eager text editor touched this Cargo.toml