### PR TITLE
JMAP: Add Capability::Sieve for groups (closes #2250)

### DIFF
--- a/crates/jmap/src/api/session.rs
+++ b/crates/jmap/src/api/session.rs
@@ -66,7 +66,7 @@ impl SessionHandler for Server {
                     .unwrap_or_else(|| Id::from(*id).to_string()),
                 is_personal,
                 is_readonly,
-                Some(&[Capability::Mail, Capability::Quota, Capability::Blob]),
+                Some(&[Capability::Mail, Capability::Quota, Capability::Blob, Capability::Sieve]),
                 &self.core.jmap.capabilities.account,
             );
         }


### PR DESCRIPTION
If I understand correctly,
this feature is implemented and works
but the capability is not set. 