### PR TITLE
curl and adduser did not make it into merge

### DIFF
--- a/resources/docker/Dockerfile.fdb
+++ b/resources/docker/Dockerfile.fdb
@@ -42,7 +42,7 @@ RUN cargo build --manifest-path=crates/main/Cargo.toml --no-default-features --f
 FROM debian:trixie-slim AS runtime
 
 COPY --from=builder /app/target/release/stalwart /usr/local/bin/stalwart
-RUN apt-get update -y && apt-get install -yq ca-certificates
+RUN apt-get update -y && apt-get install -yq --no-install-recommends ca-certificates curl adduser
 RUN curl -LO https://github.com/apple/foundationdb/releases/download/7.3.69/foundationdb-clients_7.3.69-1_amd64.deb && \
     dpkg -i foundationdb-clients_7.3.69-1_amd64.deb
 RUN useradd stalwart -s /sbin/nologin -M


### PR DESCRIPTION
My merge conflict fix from earlier lost my change for installing `adduser` and `curl`. `adduser` is again needed to install the foundationdb-clients, and curl is needed to fetch the .deb file. 