### PR TITLE
cli credentials is accountname:password

### DIFF
--- a/crates/cli/src/modules/cli.rs
+++ b/crates/cli/src/modules/cli.rs
@@ -19,8 +19,14 @@ pub struct Cli {
     /// Server base URL
     #[clap(short, long)]
     pub url: Option<String>,
-    /// Authentication credentials
-    #[clap(short, long)]
+    #[clap(
+        short,
+        long,
+        help = r#"Authentication credentials
+    accountname:password
+    orJustpassword
+(for default accountname 'admin')"#
+    )]
     pub credentials: Option<String>,
     /// Connection timeout in seconds
     #[clap(short, long)]


### PR DESCRIPTION
or just password for admin

The help of stalwart-cli has now in the help
that :  is for providing accountname in credentials.

It was needed to replace "/// text" with 'help = "text"' because the "///" doesn't do multiline nor \n expansion.