### PR TITLE
Add support for linux distros based on initd

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -124,7 +124,7 @@ main() {
     # Create service file
     say "🚀 Starting service..."
     if [ "${_os}" = "linux" ]; then
-        local _issystemdlinux=$(which systemctl)
+        local _issystemdlinux=$(command -v systemctl)
         if [ -n "$_issystemdlinux" ]; then
             create_service_linux_systemd "$_dir"
         else


### PR DESCRIPTION
This was tested against `devuan Daedalus` and `ubuntu plucky puffin`.

You can try it yourself by replacing the download step from the documentation with this:
``` sh
$ curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/yoyosource/stalwart/refs/heads/feature/initd_support/install.sh -o install.sh
```