### PR TITLE
Use latest received header in JMAP Email/import

### DIFF
--- a/crates/email/src/message/ingest.rs
+++ b/crates/email/src/message/ingest.rs
@@ -631,24 +631,6 @@ impl EmailIngest for Server {
                 .log_container_insert(SyncCollection::Thread);
         }
 
-        let received_at = params.received_at.unwrap_or_else(|| {
-            message
-                .root_part()
-                .headers()
-                .iter()
-                .filter_map(|header| {
-                    if let (HeaderName::Received, HeaderValue::Received(received)) =
-                        (&header.name, &header.value)
-                    {
-                        received.date.as_ref().map(|dt| dt.to_timestamp() as u64)
-                    } else {
-                        None
-                    }
-                })
-                .max()
-                .unwrap_or_else(now)
-        });
-
         let due = now();
         let document_id = self
             .store()
@@ -668,7 +650,7 @@ impl EmailIngest for Server {
                     keywords: params.keywords,
                     thread_id,
                 },
-                received_at,
+                params.received_at.unwrap_or_else(now),
             )
             .caused_by(trc::location!())?
             .set(


### PR DESCRIPTION
Resolves https://github.com/stalwartlabs/stalwart/discussions/2055

Currently, email imports use the received_at parameter, default to time of server import if not provided. The [JMAP spec](https://jmap.io/spec-mail.html#emailimport) says it should default to:

> time of most recent Received header, or time of import on server if none

This updates stalwart to follow the specification.