### PR TITLE
Fix IMAP UTF-7 encoding for non-BMP characters (e.g., emojis)

### DIFF
--- a/crates/imap-proto/src/utf7.rs
+++ b/crates/imap-proto/src/utf7.rs
@@ -75,9 +75,7 @@ pub fn utf7_encode(text: &str) -> String {
     let mut bits = 0;
     let mut u: u32 = 0;
 
-    for ch_ in text.chars() {
-        let ch = ch_ as u16;
-
+    for ch in text.encode_utf16() {
         if (0x20..0x7f).contains(&ch) {
             if shifted {
                 if bits > 0 {
@@ -91,7 +89,7 @@ pub fn utf7_encode(text: &str) -> String {
             if ch == 0x26 {
                 result.push_str("&-");
             } else {
-                result.push(ch_);
+                result.push((ch as u8) as char);
             }
         } else {
             if !shifted {
@@ -178,6 +176,7 @@ mod tests {
             ("&ZeVnLIqe-", "日本語"),
             ("Item 3 is &AKM-1.", "Item 3 is £1."),
             ("Plus minus &- -&- &--", "Plus minus & -& &-"),
+            ("&VMhUyNg93gQ-", "哈哈😄"),
         ] {
             assert_eq!(
                 super::utf7_encode(input),


### PR DESCRIPTION
This PR fixes an issue in the IMAP modified UTF-7 encoding logic where characters outside the Basic Multilingual Plane (BMP), such as emojis, were not being encoded correctly.

The Problem:
  The previous implementation iterated over Rust chars and simply cast them to u16 (ch as u16). This caused data loss for any character with a code point higher than U+FFFF (like 😄), as these require surrogate pairs in UTF-16 but were being truncated.

The Solution:
  Updated the utf7_encode function to iterate using text.encode_utf16(). This correctly produces the sequence of u16 code units (including surrogate pairs) required for proper IMAP UTF-7 encoding.