### PR TITLE
Fix migration from v0.11 panicking with capacity overflow

### DIFF
--- a/crates/migration/src/email_v1.rs
+++ b/crates/migration/src/email_v1.rs
@@ -519,7 +519,7 @@ fn deserialize_keyword(bytes: &mut std::slice::Iter<'_, u8>) -> Option<LegacyKey
         FORWARDED => Some(LegacyKeyword::Forwarded),
         MDN_SENT => Some(LegacyKeyword::MdnSent),
         other => {
-            let len = other - OTHER;
+            let len = other - 12;
             let mut keyword = Vec::with_capacity(len);
             for _ in 0..len {
                 keyword.push(*bytes.next()?);

--- a/crates/migration/src/object.rs
+++ b/crates/migration/src/object.rs
@@ -327,7 +327,7 @@ impl DeserializeFrom for Keyword {
             FORWARDED => Some(Keyword::Forwarded),
             MDN_SENT => Some(Keyword::MdnSent),
             other => {
-                let len = other - OTHER;
+                let len = other - 12;
                 let mut keyword = Vec::with_capacity(len);
                 for _ in 0..len {
                     keyword.push(*bytes.next()?);


### PR DESCRIPTION
v0.11 stored custom keywords as ID = 12 + string_length. The current code imports OTHER=29 from the new keyword module, so when it reads an old ID like 19 it calculates 19-29, underflows to a huge number, and panics on allocation.

The keyword that triggered this for me was NonJunk, which Thunderbird writes via IMAP to mark messages as not spam. NonJunk is 7 bytes, so v0.11 stored it as 12+7=19.