### PR TITLE
fix: Respect query arguments in Email/queryChanges

### DIFF
--- a/crates/jmap-proto/src/method/query_changes.rs
+++ b/crates/jmap-proto/src/method/query_changes.rs
@@ -130,7 +130,7 @@ impl<T: JmapObject> From<QueryChangesRequest<T>> for QueryRequest<T> {
             anchor_offset: None,
             limit: None,
             calculate_total: request.calculate_total,
-            arguments: T::QueryArguments::default(),
+            arguments: request.arguments,
         }
     }
 }


### PR DESCRIPTION
Currently, `Email/queryChanges` reports changes that have not occurred. I think this is because query arguments like `collapseThreads` are not respected, so the check for changes is running a different query than it should.

In our UI, this causes duplicate threads to show up on a query changes request.