### PR TITLE
Set name property for AddressBook account owner

### DIFF
--- a/crates/dav/src/card/proppatch.rs
+++ b/crates/dav/src/card/proppatch.rs
@@ -156,7 +156,7 @@ impl CardPropPatchRequestHandler for Server {
             // Remove properties
             if !request.set_first && !request.remove.is_empty() {
                 remove_addressbook_properties(
-                    access_token,
+                    access_token.primary_id,
                     &mut new_book,
                     std::mem::take(&mut request.remove),
                     &mut items,
@@ -175,7 +175,7 @@ impl CardPropPatchRequestHandler for Server {
             // Remove properties
             if is_success && !request.remove.is_empty() {
                 remove_addressbook_properties(
-                    access_token,
+                    access_token.primary_id,
                     &mut new_book,
                     request.remove,
                     &mut items,
@@ -257,7 +257,7 @@ impl CardPropPatchRequestHandler for Server {
             match (&property.property, property.value) {
                 (DavProperty::WebDav(WebDavProperty::DisplayName), DavValue::String(name)) => {
                     if name.len() <= self.core.groupware.live_property_size {
-                        address_book.preferences_mut(access_token).name = name;
+                        address_book.preferences_mut(access_token.primary_id).name = name;
                         items.insert_ok(property.property);
                     } else {
                         items.insert_error_with_description(
@@ -273,7 +273,7 @@ impl CardPropPatchRequestHandler for Server {
                     DavValue::String(name),
                 ) => {
                     if name.len() <= self.core.groupware.live_property_size {
-                        address_book.preferences_mut(access_token).description = Some(name);
+                        address_book.preferences_mut(access_token.primary_id).description = Some(name);
                         items.insert_ok(property.property);
                     } else {
                         items.insert_error_with_description(
@@ -440,7 +440,7 @@ fn remove_card_properties(
 }
 
 fn remove_addressbook_properties(
-    access_token: &AccessToken,
+    account_id: u32,
     book: &mut AddressBook,
     properties: Vec<DavProperty>,
     items: &mut PropStatBuilder,
@@ -448,11 +448,11 @@ fn remove_addressbook_properties(
     for property in properties {
         match &property {
             DavProperty::CardDav(CardDavProperty::AddressbookDescription) => {
-                book.preferences_mut(access_token).description = None;
+                book.preferences_mut(account_id).description = None;
                 items.insert_with_status(property, StatusCode::NO_CONTENT);
             }
             DavProperty::WebDav(WebDavProperty::DisplayName) => {
-                book.preferences_mut(access_token).name.clear();
+                book.preferences_mut(account_id).name.clear();
                 items.insert_with_status(property, StatusCode::NO_CONTENT);
             }
             DavProperty::DeadProperty(dead) => {

--- a/crates/dav/src/common/mod.rs
+++ b/crates/dav/src/common/mod.rs
@@ -442,7 +442,7 @@ impl<'x> ArchivedResource<'x> {
             }
             ArchivedResource::CalendarEvent(archive) => archive.inner.display_name.as_deref(),
             ArchivedResource::AddressBook(archive) => {
-                Some(archive.inner.preferences(access_token).name.as_str())
+                Some(archive.inner.preferences(access_token.primary_id).name.as_str())
             }
             ArchivedResource::ContactCard(archive) => archive.inner.display_name.as_deref(),
             ArchivedResource::FileNode(archive) => archive.inner.display_name.as_deref(),

--- a/crates/dav/src/common/propfind.rs
+++ b/crates/dav/src/common/propfind.rs
@@ -795,7 +795,7 @@ impl PropFindRequestHandler for Server {
                             ArchivedResource::AddressBook(book),
                         ) => {
                             if let Some(desc) =
-                                book.inner.preferences(access_token).description.as_deref()
+                                book.inner.preferences(access_token.primary_id).description.as_deref()
                             {
                                 fields.push(DavPropertyValue::new(
                                     property.clone(),

--- a/crates/groupware/src/contact/mod.rs
+++ b/crates/groupware/src/contact/mod.rs
@@ -50,11 +50,10 @@ pub struct ContactCard {
 }
 
 impl AddressBook {
-    pub fn preferences(&self, access_token: &AccessToken) -> &AddressBookPreferences {
+    pub fn preferences(&self, account_id: u32) -> &AddressBookPreferences {
         if self.preferences.len() == 1 {
             &self.preferences[0]
         } else {
-            let account_id = access_token.primary_id();
             self.preferences
                 .iter()
                 .find(|p| p.account_id == account_id)
@@ -63,8 +62,7 @@ impl AddressBook {
         }
     }
 
-    pub fn preferences_mut(&mut self, access_token: &AccessToken) -> &mut AddressBookPreferences {
-        let account_id = access_token.primary_id();
+    pub fn preferences_mut(&mut self, account_id: u32) -> &mut AddressBookPreferences {
         let idx = if let Some(idx) = self
             .preferences
             .iter()
@@ -83,11 +81,10 @@ impl AddressBook {
 }
 
 impl ArchivedAddressBook {
-    pub fn preferences(&self, access_token: &AccessToken) -> &ArchivedAddressBookPreferences {
+    pub fn preferences(&self, account_id: u32) -> &ArchivedAddressBookPreferences {
         if self.preferences.len() == 1 {
             &self.preferences[0]
         } else {
-            let account_id = access_token.primary_id();
             self.preferences
                 .iter()
                 .find(|p| p.account_id == account_id)

--- a/crates/jmap/src/addressbook/get.rs
+++ b/crates/jmap/src/addressbook/get.rs
@@ -120,14 +120,14 @@ impl AddressBookGet for Server {
                     AddressBookProperty::Name => {
                         result.insert_unchecked(
                             AddressBookProperty::Name,
-                            address_book.preferences(access_token).name.to_string(),
+                            address_book.preferences(access_token.primary_id).name.to_string(),
                         );
                     }
                     AddressBookProperty::Description => {
                         result.insert_unchecked(
                             AddressBookProperty::Description,
                             address_book
-                                .preferences(access_token)
+                                .preferences(access_token.primary_id)
                                 .description
                                 .as_ref()
                                 .map(|v| v.to_string()),
@@ -137,7 +137,7 @@ impl AddressBookGet for Server {
                         result.insert_unchecked(
                             AddressBookProperty::SortOrder,
                             address_book
-                                .preferences(access_token)
+                                .preferences(access_token.primary_id)
                                 .sort_order
                                 .to_native(),
                         );


### PR DESCRIPTION
This fixes a bug where an AddressBook created using administrator auth shows the default name of "Address Book" when accessed over CalDAV.

See https://github.com/stalwartlabs/stalwart/discussions/2693 for details