### PR TITLE
fix(directory/sql): Set principal name in QueryBy::Id to fix emails query  When using QueryBy::Id

### DIFF
--- a/crates/directory/src/backend/sql/lookup.rs
+++ b/crates/directory/src/backend/sql/lookup.rs
@@ -59,7 +59,11 @@ impl SqlDirectory {
                                     .await
                                     .caused_by(trc::location!())?,
                             )
-                            .caused_by(trc::location!())?,
+                            .caused_by(trc::location!())?
+                            .map(|mut p| {
+                                p.name = principal.name().into();
+                                p
+                            }),
                         Some(principal),
                     )
                 } else {


### PR DESCRIPTION
## Summary

Fixes a bug in the SQL directory backend where `QueryBy::Id` lookups fail to set `external_principal.name`, causing subsequent emails query to receive an empty string parameter and return no results.

## Problem

When using the SQL directory backend, operations that rely on ID-based principal lookups (such as JMAP `Identity/set`) fail with errors like:

```
"E-mail address not configured for this account."
```

This happens even when the email address is valid and exists in the database.

## Root Cause

In `lookup.rs`, the `query()` function handles three lookup types:

| QueryBy | Sets principal.name? |
|---------|---------------------|
| `QueryBy::Name` | ✅ Yes (via `.map()`) |
| `QueryBy::Id` | ❌ **No** |
| `QueryBy::Credentials` | ✅ Yes (explicit assignment) |

The `row_to_principal()` function creates a new `Principal` with `name: ""` (empty string) and never populates it from any column. For `QueryBy::Name` and `QueryBy::Credentials`, the code explicitly sets the name afterward. However, `QueryBy::Id` was missing this step.

Later, when the emails query runs, it uses `external_principal.name()` as the parameter:

```rust
let mut rows = self
    .sql_store
    .sql_query::<Rows>(
        &self.mappings.query_emails,
        vec![external_principal.name().into()],  // Empty string!
    )
```

This causes the SQL query to execute with an empty string, returning no results.

## The Fix

Added the same `.map()` pattern to `QueryBy::Id` that already exists in `QueryBy::Name`:

```rust
.map(|mut p| {
    p.name = principal.name().into();
    p
}),
```

This ensures the external principal's name is set from the stored principal retrieved by ID.